### PR TITLE
Add zustand usage example

### DIFF
--- a/clients/app/src/core/controllers/loginController/types.d.ts
+++ b/clients/app/src/core/controllers/loginController/types.d.ts
@@ -1,0 +1,28 @@
+export type Step = {
+  stepId: StepsEnum;
+  processed: boolean;
+};
+
+export enum StepsEnum {
+  start,
+  second,
+}
+
+export type Steps = Step[];
+
+export interface ILoginModel {
+  steps: Steps;
+  currentStep: StepsEnum;
+  isPending: boolean;
+  data?: any;
+}
+
+export interface IControllerMethods {
+  setPending: (value: boolean) => void;
+  processStep: (step: StepsEnum) => void;
+  startStep: (step: StepsEnum) => void;
+  ping: () => void;
+}
+
+export type GetState = () => ILoginModel;
+export type SetState = (state: (state: ILoginModel) => ILoginModel) => ILoginModel;

--- a/clients/app/src/core/services/location/locationService.ts
+++ b/clients/app/src/core/services/location/locationService.ts
@@ -1,6 +1,6 @@
 import Geolocation from 'react-native-geolocation-service';
 import { Platform, Linking, Alert, PermissionsAndroid } from 'react-native';
-import appConfig from '/app.json';
+import appConfig from '../../../app.json';
 
 //TODO locale texts
 

--- a/clients/app/src/core/services/storage/storageService.ts
+++ b/clients/app/src/core/services/storage/storageService.ts
@@ -2,16 +2,18 @@
 
 const AsyncStorage = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  setItem: (key, value) => {},
+  setItem: (key: string, value: string) => {},
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  getItem: key => {},
+  getItem: (key: string): string => {
+    return '';
+  },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  removeItem: key => {},
+  removeItem: (key: string) => {},
   clear: () => {},
 };
 
 class StorageService {
-  static setItem = async (key: string, value: string) => {
+  static setItem = async (key: string, value: any) => {
     try {
       return await AsyncStorage.setItem(key, value);
     } catch (e) {
@@ -19,9 +21,9 @@ class StorageService {
     }
   };
 
-  static getItem = async (key: string) => {
+  static getItem = async (key: string): Promise<string> => {
     try {
-      return await AsyncStorage.getItem(key);
+      return AsyncStorage.getItem(key);
     } catch (e) {
       // handle error;
       return '';
@@ -33,7 +35,7 @@ class StorageService {
   };
 
   static getObject = async (key: string) => {
-    const json = StorageService.getItem(key);
+    const json = await StorageService.getItem(key);
     return JSON.parse(json);
   };
 

--- a/clients/app/src/views/screens/JoinUs/JoinUs.tsx
+++ b/clients/app/src/views/screens/JoinUs/JoinUs.tsx
@@ -46,7 +46,7 @@ const getKeyboardOffset = (step: number): number => {
   return 0;
 };
 
-const JoinUs: React.FC<IJoinUsProps> = () => {
+const JoinUs: React.FC<IJoinUsProps> = () => sa{
   const [step, setStep] = React.useState<number>(1);
   const [phoneNumber, setPhoneNumber] = React.useState({ code: '', number: '' });
   const [isLocationEnabled, setIsLocationEnabled] = React.useState(false);

--- a/clients/app/src/views/screens/TestLoginModel/index.tsx
+++ b/clients/app/src/views/screens/TestLoginModel/index.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect } from 'react';
+import useModel from 'core/controllers/loginController';
+
+import { View, Text } from 'react-native';
+
+function TestLoginModel() {
+  const model = useModel();
+
+  useEffect(() => {
+    model.ping();
+  }, [model]);
+
+  return (
+    <View>
+      <Text>{model.isPending}</Text>
+    </View>
+  );
+}
+
+export default TestLoginModel;


### PR DESCRIPTION
This PR shows an experiment with `zustand` state manager.
This state manager lets us to separate UI logic to Business logic,  and it is a vanillajs, no Context uses.
Showing React component usage in this PR, will open a separate PR for using `setState`, `getState` methods outside react component.