### PR TITLE
View-Model type definitions added to project.

### DIFF
--- a/apis/core-api/package.json
+++ b/apis/core-api/package.json
@@ -49,6 +49,7 @@
     "@koa/cors": "^3.1.0",
     "@ultras/services": "^1.0.0",
     "@ultras/utils": "^1.0.0",
+    "@ultras/view-models": "^1.0.0",
     "aws-sdk": "^2.1080.0",
     "dotenv": "^10.0.0",
     "ioredis": "^4.28.3",

--- a/apis/core-api/src/api/middlewares/check-fan-club-existence/index.ts
+++ b/apis/core-api/src/api/middlewares/check-fan-club-existence/index.ts
@@ -1,6 +1,5 @@
 import { Middleware, Next as KoaNext } from 'koa';
 import { Context } from 'types';
-import { FanClubMemberErrorEnum } from '@ultras/utils';
 import { FanClubService } from 'core/services';
 import { ResourceNotFoundError } from 'modules/exceptions';
 
@@ -15,7 +14,6 @@ export default (routeIdParamName = 'id'): Middleware => {
 
     if (!fanClubExists) {
       throw new ResourceNotFoundError({
-        errorCode: FanClubMemberErrorEnum.notFound,
         message: 'Fan club not found.',
       });
     }

--- a/apis/core-api/src/core/controllers/CountryController/types.ts
+++ b/apis/core-api/src/core/controllers/CountryController/types.ts
@@ -1,10 +1,10 @@
+import { CountriesViewModel, CountryViewModel } from '@ultras/view-models';
 import {
   ControllerListParamsType,
   ControllerListResultType,
   ControllerByIdResultType,
   ControllerInjectionResultType,
 } from 'types';
-import { CountryAttributes } from 'core/data/models/Country';
 
 interface CountriesFilterInterface {
   name?: string;
@@ -12,6 +12,6 @@ interface CountriesFilterInterface {
 }
 
 export type CountriesListParams = ControllerListParamsType<CountriesFilterInterface>;
-export type CountriesListResult = ControllerListResultType<CountryAttributes>;
-export type CountryByIdResult = ControllerByIdResultType<CountryAttributes>;
+export type CountriesListResult = ControllerListResultType<CountriesViewModel>;
+export type CountryByIdResult = ControllerByIdResultType<CountryViewModel>;
 export type CountriesInjectDataResult = ControllerInjectionResultType;

--- a/apis/core-api/src/core/data/models/Country.ts
+++ b/apis/core-api/src/core/data/models/Country.ts
@@ -17,11 +17,11 @@ export interface CountryAttributes {
   name: string;
   code: string;
   flag: string;
-  telPrefix?: string;
+  telPrefix: string;
   dataRapidId?: number; // id of rapid api
 }
 
-export type CountryCreationAttributes = Optional<CountryAttributes, 'id'>;
+export type CountryCreationAttributes = Optional<CountryAttributes, 'id' | 'telPrefix'>;
 
 export class Country
   extends Model<CountryAttributes, CountryCreationAttributes>

--- a/clients/app/ios/Podfile.lock
+++ b/clients/app/ios/Podfile.lock
@@ -273,7 +273,7 @@ PODS:
     - React
   - react-native-geolocation-service (5.3.0-beta.4):
     - React
-  - react-native-pager-view (5.4.11):
+  - react-native-pager-view (5.4.15):
     - React-Core
   - react-native-safe-area-context (3.4.1):
     - React-Core
@@ -343,11 +343,11 @@ PODS:
     - React-perflogger (= 0.65.1)
   - RNI18n (2.0.15):
     - React
-  - RNScreens (3.12.0):
+  - RNScreens (3.13.1):
     - React-Core
     - React-RCTImage
-  - RNSVG (12.1.1):
-    - React
+  - RNSVG (12.3.0):
+    - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -534,7 +534,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 41e58e5b8e3e0bf061fdf725b03f2144014a8fb0
   react-native-blur: cad4d93b364f91e7b7931b3fa935455487e5c33c
   react-native-geolocation-service: c0efb872258ed9240f1003a70fca9e9757e5c785
-  react-native-pager-view: 7f00d63688f7df9fad86dfb0154814419cc5eb8d
+  react-native-pager-view: b1914469643f40042e65d78cbf3d3dfebd6fb0d9
   react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
   React-perflogger: fd28ee1f2b5b150b00043f0301d96bd417fdc339
   React-RCTActionSheet: 7f3fa0855c346aa5d7c60f9ced16e067db6d29fa
@@ -549,8 +549,8 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 85187f19dd9c47a7c102f9994f9d14e4dc2110de
   ReactCommon: eafed38eec7b591c31751bfa7494801618460459
   RNI18n: e2f7e76389fcc6e84f2c8733ea89b92502351fd8
-  RNScreens: 2559f98b0835103cbef3b26ba77fa61d4bb37ae7
-  RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
+  RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
+  RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   Yoga: aa0cb45287ebe1004c02a13f279c55a95f1572f4
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/clients/web-tests/src/App.tsx
+++ b/clients/web-tests/src/App.tsx
@@ -1,31 +1,48 @@
-import React, { useEffect } from 'react';
-
-import { runTest as testUtilEnums } from './lib-tests/util-enums';
-import { runTest as testUtilTimezone } from './lib-tests/util-timezone';
-import { runTest as testSdkCountry } from './lib-tests/sdk-country';
-import { runTest as testSdkCity } from './lib-tests/sdk-city';
-import { runTest as testSdkVenue } from './lib-tests/sdk-venue';
-import { runTest as testSdkTeam } from './lib-tests/sdk-team';
-import { runTest as testSdkLeague } from './lib-tests/sdk-league';
-import { runTest as testSdkMatch } from './lib-tests/sdk-match';
-import { runTest as testSdkFanClub } from './lib-tests/sdk-fanClub';
-import { runTest as testSdkAwsS3 } from './lib-tests/sdk-awsS3';
+import React, { useMemo, useState, useCallback, MouseEvent } from 'react';
+import tests from './tests';
 
 function App() {
-  useEffect(() => {
-    testUtilEnums();
-    testUtilTimezone();
-    testSdkCountry();
-    testSdkCity();
-    testSdkVenue();
-    testSdkTeam();
-    testSdkLeague();
-    testSdkMatch();
-    testSdkFanClub();
-    testSdkAwsS3();
+  const testNames = useMemo(() => Object.keys(tests), []);
+  const [running, setRunning] = useState<boolean>(false);
+
+  const onRunClick = useCallback(async (event: MouseEvent<HTMLButtonElement>) => {
+    const button = event.target as HTMLButtonElement;
+    const testName = button.dataset.testName as keyof typeof tests;
+    const testFunction = tests[testName];
+
+    if ('function' == typeof testFunction) {
+      setRunning(true);
+      await testFunction();
+      setRunning(false);
+    }
   }, []);
 
-  return <div className="App">Open console to see test results.</div>;
+  return (
+    <div className="App">
+      <table>
+        <thead>
+          <tr>
+            <th>Test name</th>
+            <th>Run</th>
+          </tr>
+        </thead>
+        <tbody>
+          {testNames.map((testName: string) => (
+            <tr key={`test-${testName}`}>
+              <td>{testName}</td>
+              <td>
+                <button data-test-name={testName} disabled={running} onClick={onRunClick}>
+                  Run test
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <p>Run test and open console to see test results.</p>
+    </div>
+  );
 }
 
 export default App;

--- a/clients/web-tests/src/lib-tests/sdk-awsS3.ts
+++ b/clients/web-tests/src/lib-tests/sdk-awsS3.ts
@@ -28,7 +28,7 @@ export const runTest = () => {
     file: fileToUpload,
   };
 
-  sdk
+  return sdk
     .upload(params)
     ?.then((result: any) => {
       console.log('UltrasS3SDK.upload():', {

--- a/clients/web-tests/src/lib-tests/sdk-city.ts
+++ b/clients/web-tests/src/lib-tests/sdk-city.ts
@@ -12,7 +12,7 @@ export const runTest = () => {
     orderAttr: 'id',
   };
 
-  sdk
+  return sdk
     .getCities(params)
     ?.then((cities: any) => {
       console.log('CitySDK.getCities():', {

--- a/clients/web-tests/src/lib-tests/sdk-country.ts
+++ b/clients/web-tests/src/lib-tests/sdk-country.ts
@@ -1,13 +1,18 @@
-import { CountrySDK } from '@ultras/core-api-sdk';
+import {
+  ApiResponseType,
+  CountriesViewModel,
+  CountrySDK,
+  ListResponseMetaType,
+} from '@ultras/core-api-sdk';
 
 const sdk = new CountrySDK('dev');
 
 export const runTest = () => {
   const params = {};
 
-  sdk
+  return sdk
     .getCountries(params)
-    ?.then((countries: any) => {
+    ?.then((countries: ApiResponseType<CountriesViewModel, ListResponseMetaType>) => {
       console.log('CountrySDK.getCountries():', {
         params,
         result: countries,

--- a/clients/web-tests/src/lib-tests/sdk-fanClub.ts
+++ b/clients/web-tests/src/lib-tests/sdk-fanClub.ts
@@ -7,7 +7,7 @@ export const runTest = () => {
     teamId: 23,
   };
 
-  sdk
+  return sdk
     .getFanClubs(params)
     ?.then((fanClubs: any) => {
       console.log('FanClubSDk.getFanClubs():', {

--- a/clients/web-tests/src/lib-tests/sdk-league.ts
+++ b/clients/web-tests/src/lib-tests/sdk-league.ts
@@ -7,7 +7,7 @@ export const runTest = () => {
     countryId: 494,
   };
 
-  sdk
+  return sdk
     .getLeagues(params)
     ?.then((leagues: any) => {
       console.log('LeagueSDK.getLeagues():', {

--- a/clients/web-tests/src/lib-tests/sdk-match.ts
+++ b/clients/web-tests/src/lib-tests/sdk-match.ts
@@ -7,7 +7,7 @@ export const runTest = () => {
     date: '2022-01-12',
   };
 
-  sdk
+  return sdk
     .getMatches(params)
     ?.then((matches: any) => {
       console.log('MatchSDK.getMatches():', {

--- a/clients/web-tests/src/lib-tests/sdk-team.ts
+++ b/clients/web-tests/src/lib-tests/sdk-team.ts
@@ -7,7 +7,7 @@ export const runTest = () => {
     cityId: 61,
   };
 
-  sdk
+  return sdk
     .getTeams(params)
     ?.then((teams: any) => {
       console.log('TeamSDK.getTeams():', {

--- a/clients/web-tests/src/lib-tests/sdk-venue.ts
+++ b/clients/web-tests/src/lib-tests/sdk-venue.ts
@@ -8,7 +8,7 @@ export const runTest = () => {
     name: 'arena',
   };
 
-  sdk
+  return sdk
     .getVenues(params)
     ?.then((venues: any) => {
       console.log('VenueSDK.getVenues():', {

--- a/clients/web-tests/src/tests.ts
+++ b/clients/web-tests/src/tests.ts
@@ -1,0 +1,25 @@
+import { runTest as testUtilEnums } from './lib-tests/util-enums';
+import { runTest as testUtilTimezone } from './lib-tests/util-timezone';
+import { runTest as testSdkCountry } from './lib-tests/sdk-country';
+import { runTest as testSdkCity } from './lib-tests/sdk-city';
+import { runTest as testSdkVenue } from './lib-tests/sdk-venue';
+import { runTest as testSdkTeam } from './lib-tests/sdk-team';
+import { runTest as testSdkLeague } from './lib-tests/sdk-league';
+import { runTest as testSdkMatch } from './lib-tests/sdk-match';
+import { runTest as testSdkFanClub } from './lib-tests/sdk-fanClub';
+import { runTest as testSdkAwsS3 } from './lib-tests/sdk-awsS3';
+
+const tests = {
+  testUtilEnums,
+  testUtilTimezone,
+  testSdkCountry,
+  testSdkCity,
+  testSdkVenue,
+  testSdkTeam,
+  testSdkLeague,
+  testSdkMatch,
+  testSdkFanClub,
+  testSdkAwsS3,
+};
+
+export default tests;

--- a/lerna.json
+++ b/lerna.json
@@ -2,9 +2,9 @@
   "packages": [
     "packages/*",
     "clients/*",
-    "bls/*",
     "apis/*",
-    "sdks/*"
+    "sdks/*",
+    "view-models/*"
   ],
   "version": "independent",
   "npmClient": "yarn",

--- a/scripts/init-app.sh
+++ b/scripts/init-app.sh
@@ -55,6 +55,7 @@ end_cmd_die $? "Couldn't make package linkage."
 ITEMS_BUILD=(\
   "packages/utils"\
   "packages/services"\
+  "view-models/core-api"\
   "sdks/core-api-sdk"\
 )
 

--- a/sdks/core-api-sdk/package.json
+++ b/sdks/core-api-sdk/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@ultras/services": "^1.0.0",
     "@ultras/utils": "^1.0.0",
+    "@ultras/view-models": "^1.0.0",
     "yargs": "^17.2.1"
   },
   "devDependencies": {

--- a/sdks/core-api-sdk/src/sdks/CoreApiBaseSDK.ts
+++ b/sdks/core-api-sdk/src/sdks/CoreApiBaseSDK.ts
@@ -1,8 +1,11 @@
 import NetworkService from '@ultras/services/NetworkService';
+import type { ResponseInterface } from '@ultras/services/NetworkService';
 import { Interceptor } from '../interceptors/types';
 import { AuthTokenInterceptor } from '../interceptors';
+import type { ApiResponseType, ListResponseMetaType } from './types';
 
 export type Mode = 'dev' | 'staging' | 'production';
+export { ApiResponseType, ListResponseMetaType, ResponseInterface };
 
 class CoreApiBaseSDK {
   protected api: NetworkService | undefined;
@@ -28,11 +31,15 @@ class CoreApiBaseSDK {
   }
 
   public ping() {
-    return this.api?.makeAPIGetRequest('/ping');
+    return this.api?.makeAPIGetRequest<{ message: string }>('/ping');
   }
 
   public getVersion() {
-    return this.api?.makeAPIGetRequest('/versions/current');
+    return this.api?.makeAPIGetRequest<{ message: string }>('/versions/current');
+  }
+
+  public getVersions() {
+    return this.api?.makeAPIGetRequest<{ [key in string]: string }>('/versions');
   }
 }
 

--- a/sdks/core-api-sdk/src/sdks/CountrySDK/index.ts
+++ b/sdks/core-api-sdk/src/sdks/CountrySDK/index.ts
@@ -1,6 +1,11 @@
 import CoreApiBaseSDK, { Mode } from '../CoreApiBaseSDK';
 import { QueryParam, DynamicQueryParam, DbIdentifier } from '../types';
-import { GetCountriesFilter } from './types';
+import type {
+  GetCountriesFilter,
+  GetCountriesResponse,
+  GetCountryResponse,
+} from './types';
+export * from './types';
 
 export class CountrySDK extends CoreApiBaseSDK {
   constructor(mode?: Mode) {
@@ -8,12 +13,12 @@ export class CountrySDK extends CoreApiBaseSDK {
   }
 
   public getCountries(params: QueryParam<GetCountriesFilter> = {}) {
-    return this.api?.makeAPIGetRequest('', {
+    return this.api?.makeAPIGetRequest<GetCountriesResponse>('', {
       query_params: params as DynamicQueryParam,
     });
   }
 
   public getCountry(id: DbIdentifier) {
-    return this.api?.makeAPIGetRequest(id.toString());
+    return this.api?.makeAPIGetRequest<GetCountryResponse>(id.toString());
   }
 }

--- a/sdks/core-api-sdk/src/sdks/CountrySDK/types.d.ts
+++ b/sdks/core-api-sdk/src/sdks/CountrySDK/types.d.ts
@@ -1,4 +1,0 @@
-export type GetCountriesFilter = {
-  name?: string;
-  code?: string;
-};

--- a/sdks/core-api-sdk/src/sdks/CountrySDK/types.ts
+++ b/sdks/core-api-sdk/src/sdks/CountrySDK/types.ts
@@ -1,0 +1,13 @@
+import { CountriesViewModel, CountryViewModel } from '@ultras/view-models';
+import { ApiResponseBodyType, ListResponseMetaType } from '../types';
+
+export type GetCountriesFilter = {
+  name?: string;
+  code?: string;
+};
+
+export type GetCountriesResponse = ApiResponseBodyType<
+  CountriesViewModel,
+  ListResponseMetaType
+>;
+export type GetCountryResponse = ApiResponseBodyType<CountryViewModel>;

--- a/sdks/core-api-sdk/src/sdks/index.ts
+++ b/sdks/core-api-sdk/src/sdks/index.ts
@@ -1,4 +1,10 @@
-export { default as CoreApiBaseSdk } from './CoreApiBaseSDK';
+export * from '@ultras/view-models';
+export {
+  default as CoreApiBaseSdk,
+  ApiResponseType,
+  ListResponseMetaType,
+  ResponseInterface,
+} from './CoreApiBaseSDK';
 
 export * from './CountrySDK';
 export * from './CitySDK';

--- a/sdks/core-api-sdk/src/sdks/types.ts
+++ b/sdks/core-api-sdk/src/sdks/types.ts
@@ -5,3 +5,27 @@ export type DbIdentifier = number;
 
 export type QueryParam<T> = T & ListRequestParams;
 export type DynamicQueryParam = Record<string, any>;
+
+export type ListResponseMetaType<T = any> = T & {
+  pagination: {
+    limit: number;
+    offset: number;
+    total: number;
+  };
+};
+
+interface PossibleMetaInterface {
+  access_token: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export type ApiResponseBodyType<TBody = any, TMeta = any> = {
+  status: number;
+  data: TBody;
+  meta: TMeta & PossibleMetaInterface;
+};
+
+export type ApiResponseType<TBody = any, TMeta = any, THead = any> = {
+  headers: THead;
+  body: ApiResponseBodyType<TBody, TMeta>;
+};

--- a/view-models/core-api/.eslintignore
+++ b/view-models/core-api/.eslintignore
@@ -1,0 +1,2 @@
+build
+node_modules

--- a/view-models/core-api/.eslintrc
+++ b/view-models/core-api/.eslintrc
@@ -1,0 +1,23 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint",
+    "prettier"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "rules": {
+    "no-console": "warn",
+    "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/triple-slash-reference": "off",
+
+    "prettier/prettier": "warn",
+    "max-len": ["error", { "code": 90 }]
+  }
+}

--- a/view-models/core-api/.prettierignore
+++ b/view-models/core-api/.prettierignore
@@ -1,0 +1,3 @@
+build
+node_modules
+hooks

--- a/view-models/core-api/.prettierrc
+++ b/view-models/core-api/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "endOfLine": "lf",
+  "tabWidth": 2,
+  "printWidth": 90,
+  
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "proseWrap": "always"
+}

--- a/view-models/core-api/README.md
+++ b/view-models/core-api/README.md
@@ -1,0 +1,1 @@
+# `core-api-view-model`

--- a/view-models/core-api/global.d.ts
+++ b/view-models/core-api/global.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Database primary key identifier:
+ *   - number -> big int
+ *   - string -> uuid
+ */
+declare type DbIdentifier = number;
+
+/**
+ * Declare same type as nullable.
+ */
+declare type Nullable<T> = null | T;
+
+/**
+ * Common field that can be contains any view-model instance, like:
+ *   - id
+ *   - createdAt
+ *   - updatedAt
+ */
+declare type ViewModel<T> = T & {
+  id: DbIdentifier;
+};

--- a/view-models/core-api/index.ts
+++ b/view-models/core-api/index.ts
@@ -1,0 +1,3 @@
+/// <reference path="./global.d.ts" />
+
+export * from './types/country';

--- a/view-models/core-api/package.json
+++ b/view-models/core-api/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "@ultras/view-models",
+    "version": "1.0.0",
+    "description": "Core api sdk",
+    "types": "./index.d.ts",
+    "license": "ISC",
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/ultras-io/ultras.git"
+    },
+    "scripts": {
+      "build": "rimraf ./build && tsc",
+      "prettier-format": "prettier --config .prettierrc 'src/**/*.(ts|js)' --write",
+      "lint": "eslint . --ext .ts",
+      "lint-fix": "eslint . --ext .ts --fix"
+    },
+    "dependencies": {
+      "@ultras/utils": "^1.0.0",
+      "yargs": "^17.2.1"
+    },
+    "devDependencies": {
+      "@typescript-eslint/eslint-plugin": "^4.31.1",
+      "@typescript-eslint/parser": "^4.32.0",
+      "eslint": "^7.32.0",
+      "eslint-config-prettier": "^8.3.0",
+      "eslint-plugin-prettier": "^4.0.0",
+      "prettier": "^2.5.1",
+      "typescript": "^4.4.4"
+    },
+    "bugs": {
+      "url": "https://github.com/ultras-io/ultras/issues"
+    }
+}

--- a/view-models/core-api/tsconfig.json
+++ b/view-models/core-api/tsconfig.json
@@ -1,0 +1,60 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
+    "module": "esnext" /* Specify module code generation: 'none', commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "lib": [
+      "esnext",
+      "dom"
+    ] /* Specify library files to be included in the compilation:  */,
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    "declarationDir": "./build/types",
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "build" /* Redirect output structure to the directory. */,
+    "rootDir": "types" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
+    // "removeComments": false,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    "esModuleInterop": true
+  },
+  "include": ["types/*.ts", "global.d.ts"]
+}

--- a/view-models/core-api/types/country.ts
+++ b/view-models/core-api/types/country.ts
@@ -1,0 +1,8 @@
+export type CountryViewModel = ViewModel<{
+  name: string;
+  code: string;
+  flag: string;
+  telPrefix: Nullable<string>;
+}>;
+
+export type CountriesViewModel = Array<CountryViewModel>;


### PR DESCRIPTION
Now api-response types must be declared in `@ultras/view-models` and will be used in API and UI apps.
This commit includes `Country` type definition only which is declared in `@ultras/view-models` and used in API (`@ultras/core-api`) and UI Test WebApp (`@ultras/web-tests`).

