### PR TITLE
Fix/network service production build

### DIFF
--- a/apis/core-api/tsconfig.json
+++ b/apis/core-api/tsconfig.json
@@ -4,8 +4,14 @@
     "target": "es6" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "lib": [
       "es2017",
+
+      // @TODO: "dom" must be removed from this list, we need a another way
+      // we using "dom" there depends on `NetworkService`, the service
+      // already using "dom" inside, so core api must be know client-side
+      // types too.
       "dom"
     ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
+
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     "experimentalDecorators": true /* Enable experimental support for TC39 stage 2 draft decorators. */,
     "emitDecoratorMetadata": true /* Emit design-type metadata for decorated declarations in source files. */,

--- a/apis/core-api/tsconfig.json
+++ b/apis/core-api/tsconfig.json
@@ -3,7 +3,8 @@
     /* Language and Environment */
     "target": "es6" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "lib": [
-      "es2017"
+      "es2017",
+      "dom"
     ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     "experimentalDecorators": true /* Enable experimental support for TC39 stage 2 draft decorators. */,

--- a/packages/services/NetworkService/index.ts
+++ b/packages/services/NetworkService/index.ts
@@ -227,8 +227,8 @@ class NetworkService {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       fetch(url, fetchOptions)
-        .then(response => resolve(response))
-        .catch(error => reject(error));
+        .then((response: Response) => resolve(response))
+        .catch((error: Error) => reject(error));
     });
   };
 }

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -44,10 +44,10 @@
     "@types/node": "^17.0.10",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.32.0",
+    "dotenv": "^14.2.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "dotenv": "^14.2.0",
     "mocha": "^9.1.4",
     "prettier": "^2.5.1",
     "typescript": "^4.4.4"


### PR DESCRIPTION
As `NetworkService` is designed to use on both client and server sides, our core API build failed, because inside of service already used types/futures that are available on browser API only.

So this is a temporary fix, we need to change this part later.
