### PR TITLE
Start React Native app without cache.

### DIFF
--- a/clients/app/package.json
+++ b/clients/app/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "start": "react-native start",
+    "start": "react-native start --reset-cache",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.(ts|tsx|js|jsx)' --write",

--- a/scripts/init-app.sh
+++ b/scripts/init-app.sh
@@ -79,6 +79,7 @@ for ITEM_BUILD in ${ITEMS_BUILD[@]}; do
 
   if [[ ! -d "build" ]] ; then
     print_action_log "Building sub-package [$PKG_NAME]"
+    yarn build >> "$INIT_LOG" # > /dev/null 2>&1
     end_cmd_die $? "Couldn't build package $PKG_NAME."
   fi
 done


### PR DESCRIPTION
Clear previous metro app cache before starting the app.