### PR TITLE
CRUD Default limit change

### DIFF
--- a/clients/app/src/stores/generateCRUD/generateCRUD.ts
+++ b/clients/app/src/stores/generateCRUD/generateCRUD.ts
@@ -19,7 +19,7 @@ import type {
   FullFilterable,
 } from './types';
 
-export const defaultLimit = 50;
+export const defaultLimit = 10;
 
 export const generateCRUD = <
   TData extends object,
@@ -152,8 +152,15 @@ export const generateCRUD = <
 
           try {
             const filterData = {
-              ...(list.filter || {}),
+              // the limit attribute can be overriden by updateFilter(),
+              // that's why limit is above spread operator.
               limit: itemsLimit,
+
+              // spreading provided filter.
+              ...(list.filter || {}),
+
+              // but offset is calculated internally, that's why offset
+              // is below spread operator.
               offset: itemsCount,
             };
 

--- a/clients/app/src/stores/generateCRUD/types.ts
+++ b/clients/app/src/stores/generateCRUD/types.ts
@@ -26,7 +26,7 @@ export interface InitStoreParamsInterface<TData> {
 }
 
 export type FullFilterable<TFilter> = TFilter & ListRequestParams;
-export type Filterable<TFilter> = Omit<FullFilterable<TFilter>, 'limit' | 'offset'>;
+export type Filterable<TFilter> = Omit<FullFilterable<TFilter>, 'offset'>;
 
 export interface StateFieldAddInterface<TFieldValue = string> {
   isValid: boolean;


### PR DESCRIPTION
This PR includes:

1) CRUD fetch default limit change from `50` to `10`.
2) Set fetch data limit via `updateFilter` in UI.
