### PR TITLE
Events/Matches top tab navigation height fix

### DIFF
--- a/clients/app/ios/Podfile.lock
+++ b/clients/app/ios/Podfile.lock
@@ -212,7 +212,7 @@ PODS:
     - React
   - react-native-geolocation-service (5.3.0-beta.4):
     - React
-  - react-native-pager-view (5.4.22):
+  - react-native-pager-view (5.4.1):
     - React-Core
   - react-native-safe-area-context (3.4.1):
     - React-Core
@@ -434,7 +434,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 41e58e5b8e3e0bf061fdf725b03f2144014a8fb0
   react-native-blur: cad4d93b364f91e7b7931b3fa935455487e5c33c
   react-native-geolocation-service: c0efb872258ed9240f1003a70fca9e9757e5c785
-  react-native-pager-view: c0ff94cb1e670bcba387bdf575515c58dfa85f04
+  react-native-pager-view: 43f51f45f37ec9715f6c188e4af46ccdf79872e8
   react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
   React-perflogger: fd28ee1f2b5b150b00043f0301d96bd417fdc339
   React-RCTActionSheet: 7f3fa0855c346aa5d7c60f9ced16e067db6d29fa
@@ -448,7 +448,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 92d41c2442e5328cc4d342cd7f78e5876b68bae5
   React-runtimeexecutor: 85187f19dd9c47a7c102f9994f9d14e4dc2110de
   ReactCommon: eafed38eec7b591c31751bfa7494801618460459
-  RNCAsyncStorage: 86050d31a1cdc564876f68d8e342688b29f9b186
+  RNCAsyncStorage: 466b9df1a14bccda91da86e0b7d9a345d78e1673
   RNI18n: e2f7e76389fcc6e84f2c8733ea89b92502351fd8
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
@@ -456,4 +456,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: f6cdbb5409a5c9e0c53fc268a6d8c9922d65d92d
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/clients/app/package.json
+++ b/clients/app/package.json
@@ -30,7 +30,7 @@
     "react-native-geolocation-service": "^5.3.0-beta.3",
     "react-native-i18n": "^2.0.15",
     "react-native-linear-gradient": "^2.5.6",
-    "react-native-pager-view": "^5.4.4",
+    "react-native-pager-view": "5.4.1",
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.7.2",
     "react-native-svg": "^12.1.1",

--- a/clients/app/src/views/components/base/Container/Container.tsx
+++ b/clients/app/src/views/components/base/Container/Container.tsx
@@ -13,7 +13,7 @@ const Container: React.FC<IContainerProps> = ({
   const content = withSuspense ? (
     <React.Suspense fallback={<Loader />}>{children}</React.Suspense>
   ) : (
-    <>children</>
+    children
   );
 
   return withBg ? (


### PR DESCRIPTION
Fixed an issue that sometimes crop the `Events` / `Matches` screens in `TopTabNavigation`.