### PR TITLE
Favorite teams subquery fixed

### DIFF
--- a/apis/core-api/src/core/services/FavoriteTeamService.ts
+++ b/apis/core-api/src/core/services/FavoriteTeamService.ts
@@ -133,7 +133,7 @@ class FavoriteTeamService extends BaseService {
     // generate subquery
     const subquerySel = db.sequelize.dialect.queryGenerator
       .selectQuery(db.FavoriteTeam.getTableName(), {
-        attributes: ['id'],
+        attributes: ['teamId'],
         where: {
           userId: params.userId,
         },


### PR DESCRIPTION
Favorite teams sub-query `teamId` field used instead of `id`, because sub-query called thought pivot table.