### PR TITLE
CRUD delete functionality + favorite team delete implementation

### DIFF
--- a/apis/core-api/src/api/routes/v1/favoriteTeams/ControllerAdapter.ts
+++ b/apis/core-api/src/api/routes/v1/favoriteTeams/ControllerAdapter.ts
@@ -87,6 +87,23 @@ class ControllerAdapter {
 
     return ctx.noContent();
   }
+
+  /**
+   * Remove team from favorites.
+   */
+  static async removeByTeamId(ctx: Context) {
+    /** VALIDATIONS, PARAMETERS */
+    const { id } = ctx.request.params;
+    const { userId } = ctx.user;
+
+    /** CONTROLLERS */
+    await FavoriteTeamController.remove({
+      teamId: id,
+      userId: userId,
+    });
+
+    return ctx.noContent();
+  }
 }
 
 export default ControllerAdapter;

--- a/apis/core-api/src/api/routes/v1/favoriteTeams/index.ts
+++ b/apis/core-api/src/api/routes/v1/favoriteTeams/index.ts
@@ -10,5 +10,6 @@ router.get('/', checkUserAuth(), ControllerAdapter.getAll);
 router.get('/:id', checkUserAuth(), ControllerAdapter.getById);
 router.post('/', checkUserAuth(), ControllerAdapter.add);
 router.delete('/:id', checkUserAuth(), ControllerAdapter.remove);
+router.delete('/teams/:id', checkUserAuth(), ControllerAdapter.removeByTeamId);
 
 export default router;

--- a/apis/core-api/src/core/data/models/FavoriteTeam.ts
+++ b/apis/core-api/src/core/data/models/FavoriteTeam.ts
@@ -57,7 +57,7 @@ module.exports = (sequelize: Sequelize): typeof FavoriteTeam => {
       },
       userId: {
         type: DataTypes.BIGINT,
-        allowNull: true,
+        allowNull: false,
         references: {
           model: {
             tableName: resources.USER.RELATION,
@@ -69,7 +69,7 @@ module.exports = (sequelize: Sequelize): typeof FavoriteTeam => {
       },
       teamId: {
         type: DataTypes.INTEGER,
-        allowNull: true,
+        allowNull: false,
         references: {
           model: {
             tableName: resources.TEAM.RELATION,

--- a/apis/core-api/src/core/services/BaseService.ts
+++ b/apis/core-api/src/core/services/BaseService.ts
@@ -81,7 +81,7 @@ abstract class BaseService {
     }
 
     const list = Array.isArray(value) ? value : value.split(separator);
-    return list;
+    return list.filter((id: null | ResourceIdentifier) => !!id);
   }
 
   /**

--- a/apis/core-api/src/core/services/FavoriteTeamService.ts
+++ b/apis/core-api/src/core/services/FavoriteTeamService.ts
@@ -108,9 +108,9 @@ class FavoriteTeamService extends BaseService {
     }
 
     const data: Array<FavoriteTeamCreationAttributes> = teamId.map(
-      (teamId: ResourceIdentifier) => ({
+      (teamIdItem: ResourceIdentifier) => ({
         userId,
-        teamId,
+        teamId: teamIdItem,
         deletedAt: null,
       })
     );
@@ -290,6 +290,7 @@ class FavoriteTeamService extends BaseService {
     await db.FavoriteTeam.destroy(
       {
         where: condition,
+        force: true,
       },
       { transaction }
     );

--- a/clients/app/src/stores/countries.ts
+++ b/clients/app/src/stores/countries.ts
@@ -18,7 +18,15 @@ type FilterType = Filterable<GetCountriesFilter>;
 const sdk = new CountrySDK('dev');
 
 const buildCountriesStore = (params: Partial<ParamType> = {}) => {
-  return generateCRUD<CountryViewModel, null, null, FilterType, 'list' | 'single'>({
+  return generateCRUD<
+    CountryViewModel,
+    CountryViewModel,
+    null,
+    null,
+    null,
+    FilterType,
+    'list' | 'single'
+  >({
     keys: ['list', 'single'],
     ...(params as ParamType),
 

--- a/clients/app/src/stores/events.ts
+++ b/clients/app/src/stores/events.ts
@@ -15,6 +15,10 @@ import {
 type ParamType = InitStoreParamsInterface<EventViewModel>;
 type FilterType = Filterable<GetEventsFilter>;
 
+type TDeleteEvent = {
+  eventId: ResourceIdentifier;
+};
+
 const sdk = new EventSDK('dev');
 
 const buildEventsStore = (params: Partial<ParamType> = {}) => {
@@ -22,10 +26,12 @@ const buildEventsStore = (params: Partial<ParamType> = {}) => {
     EventViewModel,
     EventViewModel,
     EventViewModel,
+    EventViewModel,
+    TDeleteEvent,
     FilterType,
-    'list' | 'single'
+    'list' | 'single' | 'delete'
   >({
-    keys: ['list', 'single'],
+    keys: ['list', 'single', 'delete'],
     ...(params as ParamType),
 
     loadAll: (filter: FullFilterable<GetEventsFilter>) => {
@@ -36,6 +42,10 @@ const buildEventsStore = (params: Partial<ParamType> = {}) => {
 
     loadSingle: (id: ResourceIdentifier) => {
       return sdk.getEvent(id);
+    },
+
+    remove: (data: TDeleteEvent) => {
+      return sdk.deleteEvent(data.eventId);
     },
   });
 };

--- a/clients/app/src/stores/fanClubMembers.ts
+++ b/clients/app/src/stores/fanClubMembers.ts
@@ -15,6 +15,11 @@ import {
 type ParamType = InitStoreParamsInterface<FanClubMemberViewModel>;
 type FilterType = Filterable<GetFanClubMembershipsFilter>;
 
+type TDeleteEvent = {
+  fanClubId: ResourceIdentifier;
+  membershipId: ResourceIdentifier;
+};
+
 interface LoadAllParams extends FullFilterable<GetFanClubMembershipsFilter> {
   fanClubId: number;
 }
@@ -24,12 +29,14 @@ const sdk = new FanClubMembershipSDK('dev');
 const buildFanClubMembersStore = (params: Partial<ParamType> = {}) => {
   return generateCRUD<
     FanClubMemberViewModel,
+    FanClubMemberViewModel,
     ResourceIdentifier,
     FanClubMemberViewModel,
+    TDeleteEvent,
     FilterType,
-    'list'
+    'list' | 'delete'
   >({
-    keys: ['list'],
+    keys: ['list', 'delete'],
     ...(params as ParamType),
 
     loadAll: (filter: LoadAllParams) => {
@@ -46,6 +53,10 @@ const buildFanClubMembersStore = (params: Partial<ParamType> = {}) => {
     // create: (data: Partial<FanClubViewModel>) => {
     //   return sdk.create(data);
     // },
+
+    remove: (data: TDeleteEvent) => {
+      return sdk.leaveFanClub(data.fanClubId, data.membershipId);
+    },
   });
 };
 

--- a/clients/app/src/stores/fanClubs.ts
+++ b/clients/app/src/stores/fanClubs.ts
@@ -15,6 +15,10 @@ import {
 type ParamType = InitStoreParamsInterface<FanClubViewModel>;
 type FilterType = Filterable<GetFanClubsFilter>;
 
+type TDeleteEvent = {
+  eventId: ResourceIdentifier;
+};
+
 const sdk = new FanClubSDK('dev');
 
 const buildFanClubsStore = (params: Partial<ParamType> = {}) => {
@@ -23,6 +27,8 @@ const buildFanClubsStore = (params: Partial<ParamType> = {}) => {
     FanClubViewModel,
     FanClubViewModel,
     FanClubViewModel,
+    FanClubViewModel,
+    TDeleteEvent,
     FilterType,
     'list' | 'single'
   >({

--- a/clients/app/src/stores/favoriteTeams.ts
+++ b/clients/app/src/stores/favoriteTeams.ts
@@ -15,11 +15,27 @@ import {
 type ParamType = InitStoreParamsInterface<TeamViewModel>;
 type FilterType = Filterable<GetFavoriteTeamsFilter>;
 
+type TCreateEvent = {
+  teamId: ResourceIdentifier;
+};
+type TDeleteEvent = {
+  favoriteTeamId?: ResourceIdentifier;
+  teamId?: ResourceIdentifier;
+};
+
 const sdk = new FavoriteTeamSDK('dev');
 
 const buildFavoriteTeamsStore = (params: Partial<ParamType> = {}) => {
-  return generateCRUD<TeamViewModel, ResourceIdentifier, null, FilterType, 'list'>({
-    keys: ['list'],
+  return generateCRUD<
+    TeamViewModel,
+    TeamViewModel,
+    TCreateEvent,
+    null,
+    TDeleteEvent,
+    FilterType,
+    'list' | 'add' | 'delete'
+  >({
+    keys: ['list', 'add', 'delete'],
 
     ...(params as ParamType),
 
@@ -29,9 +45,19 @@ const buildFavoriteTeamsStore = (params: Partial<ParamType> = {}) => {
       });
     },
 
-    // create: (data: ResourceIdentifier) => {
-    //   return sdk.add(data);
-    // },
+    create: (data: TCreateEvent) => {
+      return sdk.add(data.teamId);
+    },
+
+    remove: (data: TDeleteEvent) => {
+      if (data.teamId) {
+        return sdk.removeByTeamId(data.teamId);
+      }
+
+      if (data.favoriteTeamId) {
+        return sdk.remove(data.favoriteTeamId);
+      }
+    },
   });
 };
 

--- a/clients/app/src/stores/generateCRUD/crud/add.ts
+++ b/clients/app/src/stores/generateCRUD/crud/add.ts
@@ -18,7 +18,7 @@ type CurrentStoreKeyType = 'add';
 
 // build initial state for add.
 export const buildInitialState = <TData, TFilter>(
-  state: ExtractStateType<null, TData, null, CurrentStoreKeyType, TFilter>,
+  state: ExtractStateType<null, null, TData, null, null, CurrentStoreKeyType, TFilter>,
   scheme: SchemeInterface | null | undefined
 ) => {
   // @ts-ignore
@@ -41,10 +41,34 @@ export const buildInitialState = <TData, TFilter>(
 
 // build actions for list.
 export const buildActions = <TData, TFilter>(
-  actions: ExtractActionType<null, TData, null, CurrentStoreKeyType, TFilter>,
-  getState: StateGetterCallType<null, TData, null, CurrentStoreKeyType, TFilter>,
-  setState: StateSetterCallType<null, TData, null, CurrentStoreKeyType, TFilter>,
-  interceptors: ExtractInterceptorType<null, TData, null, CurrentStoreKeyType, TFilter>
+  actions: ExtractActionType<null, null, TData, null, null, CurrentStoreKeyType, TFilter>,
+  getState: StateGetterCallType<
+    null,
+    null,
+    TData,
+    null,
+    null,
+    CurrentStoreKeyType,
+    TFilter
+  >,
+  setState: StateSetterCallType<
+    null,
+    null,
+    TData,
+    null,
+    null,
+    CurrentStoreKeyType,
+    TFilter
+  >,
+  interceptors: ExtractInterceptorType<
+    null,
+    null,
+    TData,
+    null,
+    null,
+    CurrentStoreKeyType,
+    TFilter
+  >
 ) => {
   // add setFieldValue method to action list, that setting value property
   // by provided key and value, and it will call validate interceptor method
@@ -65,7 +89,10 @@ export const buildActions = <TData, TFilter>(
     add.data[key].valueToSave = value;
     add.data[key].errors = [];
 
-    if (typeof interceptors.scheme[key] !== 'undefined') {
+    if (
+      typeof interceptors.scheme !== 'undefined' &&
+      typeof interceptors.scheme[key] !== 'undefined'
+    ) {
       const schemeItem = interceptors.scheme[key];
 
       if (typeof schemeItem.processValue === 'function') {
@@ -89,8 +116,8 @@ export const buildActions = <TData, TFilter>(
     add.data[key].isValid = add.data[key].errors.length === 0;
     add.valid = true;
 
-    for (const dataKey in Object.keys(add.data)) {
-      const isValid = add.data![dataKey].isValid;
+    for (const dataKey of Object.keys(add.data)) {
+      const isValid = add.data[dataKey].isValid;
       if (!isValid) {
         add.valid = false;
         break;
@@ -110,7 +137,12 @@ export const buildActions = <TData, TFilter>(
 
     const addData = add.data!;
 
-    const state = Object.keys(interceptors.scheme).reduce((acc, key) => {
+    const mapData = interceptors.scheme || addData;
+    if (!mapData) {
+      return null;
+    }
+
+    const state = Object.keys(mapData).reduce((acc, key) => {
       acc[key] = addData[key];
       return acc;
     }, {} as StateDataSchemeInterface);
@@ -127,15 +159,14 @@ export const buildActions = <TData, TFilter>(
     // received result must be sent to backend, otherwise state values will
     // be used to send to backend.
     if (typeof interceptors.beforeSend === 'function') {
-      const beforeSendCall =
-        interceptors.beforeSend as unknown as BeforeSendInterface<TData>;
+      const beforeSendCall = interceptors.beforeSend as BeforeSendInterface<TData>;
       result = await beforeSendCall(state);
 
       if (!result) {
         return null;
       }
     } else {
-      result = Object.keys(interceptors.scheme).reduce((acc, key) => {
+      result = Object.keys(mapData).reduce((acc, key) => {
         acc[key] = addData[key].valueToSave || addData[key].valueOriginal;
         return acc;
       }, {} as any);
@@ -166,13 +197,23 @@ export const buildActions = <TData, TFilter>(
 
 // build root actions for add.
 export const buildRootAction = <TData, TFilter>(
-  rootActions: ExtractActionType<null, TData, null, CurrentStoreKeyType, TFilter>,
-  storeVanilla: RootStoreType<null, TData, null, CurrentStoreKeyType, TFilter>
+  rootActions: ExtractActionType<
+    null,
+    null,
+    TData,
+    null,
+    null,
+    CurrentStoreKeyType,
+    TFilter
+  >,
+  storeVanilla: RootStoreType<null, null, TData, null, null, CurrentStoreKeyType, TFilter>
 ) => {
   const getVanillaState = () => {
     return storeVanilla.getState() as unknown as ExtractActionType<
       null,
+      null,
       TData,
+      null,
       null,
       CurrentStoreKeyType,
       TFilter

--- a/clients/app/src/stores/generateCRUD/crud/delete.ts
+++ b/clients/app/src/stores/generateCRUD/crud/delete.ts
@@ -1,0 +1,112 @@
+import type {
+  RootStoreType,
+  ExtractStateType,
+  ExtractActionType,
+  ExtractInterceptorType,
+  StateGetterCallType,
+  StateSetterCallType,
+} from '../types/store';
+
+type CurrentStoreKeyType = 'delete';
+
+// build initial state for delete.
+export const buildInitialState = <TData, TFilter>(
+  state: ExtractStateType<null, null, null, null, TData, CurrentStoreKeyType, null>
+) => {
+  state.delete = {
+    status: 'loading',
+    error: null,
+  };
+};
+
+// build actions for list.
+export const buildActions = <TData, TFilter>(
+  actions: ExtractActionType<null, null, null, null, TData, CurrentStoreKeyType, TFilter>,
+  getState: StateGetterCallType<
+    null,
+    null,
+    null,
+    null,
+    TData,
+    CurrentStoreKeyType,
+    TFilter
+  >,
+  setState: StateSetterCallType<
+    null,
+    null,
+    null,
+    null,
+    TData,
+    CurrentStoreKeyType,
+    TFilter
+  >,
+  interceptors: ExtractInterceptorType<
+    null,
+    null,
+    null,
+    null,
+    TData,
+    CurrentStoreKeyType,
+    TFilter
+  >
+) => {
+  // add delete method to action delete, that just calling delete interceptor method
+  // which sending data to api server
+  actions.remove = async (deleteData: TData | null): Promise<void | null> => {
+    if (!deleteData) {
+      return null;
+    }
+
+    const deleteState = getState().delete;
+    deleteState.status = 'loading';
+    setState({ delete: deleteState });
+
+    try {
+      const apiResult = await interceptors.remove(deleteData);
+      if (!apiResult) {
+        throw new Error('"delete" returned empty result.');
+      }
+
+      deleteState.status = 'success';
+
+      setState({ delete: deleteState });
+      return;
+    } catch (e) {
+      deleteState.status = 'error';
+      deleteState.error = e as Error;
+
+      setState({ delete: deleteState });
+      return null;
+    }
+  };
+};
+
+// build root actions for add.
+export const buildRootAction = <TData, TFilter>(
+  rootActions: ExtractActionType<
+    null,
+    null,
+    null,
+    null,
+    TData,
+    CurrentStoreKeyType,
+    TFilter
+  >,
+  storeVanilla: RootStoreType<null, null, null, null, TData, CurrentStoreKeyType, TFilter>
+) => {
+  const getVanillaState = () => {
+    return storeVanilla.getState() as unknown as ExtractActionType<
+      null,
+      null,
+      null,
+      null,
+      TData,
+      CurrentStoreKeyType,
+      TFilter
+    >;
+  };
+
+  rootActions.remove = (data: TData) => {
+    return getVanillaState().remove(data);
+  };
+};

--- a/clients/app/src/stores/generateCRUD/crud/list.ts
+++ b/clients/app/src/stores/generateCRUD/crud/list.ts
@@ -17,7 +17,7 @@ export const defaultLimit = 10;
 
 // build initial state for list.
 export const buildInitialState = <TData, TFilter>(
-  state: ExtractStateType<TData, null, null, CurrentStoreKeyType, TFilter>
+  state: ExtractStateType<TData, null, null, null, null, CurrentStoreKeyType, TFilter>
 ) => {
   state.list = {
     status: 'loading',
@@ -35,10 +35,34 @@ export const buildInitialState = <TData, TFilter>(
 
 // build actions for list.
 export const buildActions = <TData, TFilter>(
-  actions: ExtractActionType<TData, null, null, CurrentStoreKeyType, TFilter>,
-  getState: StateGetterCallType<TData, null, null, CurrentStoreKeyType, TFilter>,
-  setState: StateSetterCallType<TData, null, null, CurrentStoreKeyType, TFilter>,
-  interceptors: ExtractInterceptorType<TData, null, null, CurrentStoreKeyType, TFilter>,
+  actions: ExtractActionType<TData, null, null, null, null, CurrentStoreKeyType, TFilter>,
+  getState: StateGetterCallType<
+    TData,
+    null,
+    null,
+    null,
+    null,
+    CurrentStoreKeyType,
+    TFilter
+  >,
+  setState: StateSetterCallType<
+    TData,
+    null,
+    null,
+    null,
+    null,
+    CurrentStoreKeyType,
+    TFilter
+  >,
+  interceptors: ExtractInterceptorType<
+    TData,
+    null,
+    null,
+    null,
+    null,
+    CurrentStoreKeyType,
+    TFilter
+  >,
   fetchLimit: number = defaultLimit
 ) => {
   // add updateFilter method to action list, that partially updates filter values,
@@ -119,12 +143,22 @@ export const buildActions = <TData, TFilter>(
 
 // build root actions for list.
 export const buildRootAction = <TData, TFilter>(
-  rootActions: ExtractActionType<TData, null, null, CurrentStoreKeyType, TFilter>,
-  storeVanilla: RootStoreType<TData, null, null, CurrentStoreKeyType, TFilter>
+  rootActions: ExtractActionType<
+    TData,
+    null,
+    null,
+    null,
+    null,
+    CurrentStoreKeyType,
+    TFilter
+  >,
+  storeVanilla: RootStoreType<TData, null, null, null, null, CurrentStoreKeyType, TFilter>
 ) => {
   const getVanillaState = () => {
     return storeVanilla.getState() as unknown as ExtractActionType<
       TData,
+      null,
+      null,
       null,
       null,
       CurrentStoreKeyType,

--- a/clients/app/src/stores/generateCRUD/crud/single.ts
+++ b/clients/app/src/stores/generateCRUD/crud/single.ts
@@ -12,7 +12,7 @@ type CurrentStoreKeyType = 'single';
 
 // build initial state for single.
 export const buildInitialState = <TData, TFilter>(
-  state: ExtractStateType<TData, null, null, CurrentStoreKeyType, TFilter>
+  state: ExtractStateType<null, TData, null, null, null, CurrentStoreKeyType, TFilter>
 ) => {
   state.single = {
     status: 'loading',
@@ -23,10 +23,34 @@ export const buildInitialState = <TData, TFilter>(
 
 // build actions for list.
 export const buildActions = <TData, TFilter>(
-  actions: ExtractActionType<TData, null, null, CurrentStoreKeyType, TFilter>,
-  getState: StateGetterCallType<TData, null, null, CurrentStoreKeyType, TFilter>,
-  setState: StateSetterCallType<TData, null, null, CurrentStoreKeyType, TFilter>,
-  interceptors: ExtractInterceptorType<TData, null, null, CurrentStoreKeyType, TFilter>
+  actions: ExtractActionType<null, TData, null, null, null, CurrentStoreKeyType, TFilter>,
+  getState: StateGetterCallType<
+    null,
+    TData,
+    null,
+    null,
+    null,
+    CurrentStoreKeyType,
+    TFilter
+  >,
+  setState: StateSetterCallType<
+    null,
+    TData,
+    null,
+    null,
+    null,
+    CurrentStoreKeyType,
+    TFilter
+  >,
+  interceptors: ExtractInterceptorType<
+    null,
+    TData,
+    null,
+    null,
+    null,
+    CurrentStoreKeyType,
+    TFilter
+  >
 ) => {
   // add getSingle method to action list, that just calling loadSingle interceptor method
   // and updates "single" state
@@ -57,12 +81,22 @@ export const buildActions = <TData, TFilter>(
 
 // build root actions for single.
 export const buildRootAction = <TData, TFilter>(
-  rootActions: ExtractActionType<TData, null, null, CurrentStoreKeyType, TFilter>,
-  storeVanilla: RootStoreType<TData, null, null, CurrentStoreKeyType, TFilter>
+  rootActions: ExtractActionType<
+    null,
+    TData,
+    null,
+    null,
+    null,
+    CurrentStoreKeyType,
+    TFilter
+  >,
+  storeVanilla: RootStoreType<null, TData, null, null, null, CurrentStoreKeyType, TFilter>
 ) => {
   const getVanillaState = () => {
     return storeVanilla.getState() as unknown as ExtractActionType<
+      null,
       TData,
+      null,
       null,
       null,
       CurrentStoreKeyType,

--- a/clients/app/src/stores/generateCRUD/generateCRUD.ts
+++ b/clients/app/src/stores/generateCRUD/generateCRUD.ts
@@ -7,25 +7,45 @@ import buildRootActions from './utils/buildRootActions';
 import type { StateKeyType, ParamsType, ExtractStateAndActionType } from './types';
 
 export const generateCRUD = <
-  TDataViewModel,
+  TDataList,
+  TDataSingle,
   TDataCreate,
   TDataUpdate,
+  TDataDelete,
   TFilter,
   TKey extends StateKeyType = StateKeyType
 >(
-  params: ParamsType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter>
+  params: ParamsType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TKey,
+    TFilter
+  >
 ) => {
   const storeVanilla = createVanilla<
-    ExtractStateAndActionType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter>
+    ExtractStateAndActionType<
+      TDataList,
+      TDataSingle,
+      TDataCreate,
+      TDataUpdate,
+      TDataDelete,
+      TKey,
+      TFilter
+    >
   >((stateSetter, stateGetter) => buildStateAndActions(params, stateSetter, stateGetter));
 
   const storeReact = createReact(storeVanilla);
 
   const useSelector = <TPassedKeys extends TKey>(...keys: Array<TPassedKeys>) => {
     const state = storeReact() as ExtractStateAndActionType<
-      TDataViewModel,
+      TDataList,
+      TDataSingle,
       TDataCreate,
       TDataUpdate,
+      TDataDelete,
       TPassedKeys,
       TFilter
     >;
@@ -37,7 +57,7 @@ export const generateCRUD = <
       // @ts-ignore
       acc[value] = state[value];
       return acc;
-    }, {} as ExtractStateAndActionType<TDataViewModel, TDataCreate, TDataUpdate, TPassedKeys, TFilter>);
+    }, {} as ExtractStateAndActionType<TDataList, TDataSingle, TDataCreate, TDataUpdate, TDataDelete, TPassedKeys, TFilter>);
   };
 
   return {

--- a/clients/app/src/stores/generateCRUD/types/common.ts
+++ b/clients/app/src/stores/generateCRUD/types/common.ts
@@ -17,7 +17,7 @@ export type FullFilterable<TFilter> = TFilter & ListRequestParams;
 export type Filterable<TFilter> = Omit<FullFilterable<TFilter>, 'offset'>;
 
 // export type StateKeyType = 'list' | 'single' | 'add' | 'update' | 'delete';
-export type StateKeyType = 'list' | 'single' | 'add';
+export type StateKeyType = 'list' | 'single' | 'add' | 'delete';
 export type StateKeyParamType = Record<StateKeyType, boolean>;
 
 export type StatusType = 'loading' | 'error' | 'success';

--- a/clients/app/src/stores/generateCRUD/types/crud/delete.ts
+++ b/clients/app/src/stores/generateCRUD/types/crud/delete.ts
@@ -1,0 +1,21 @@
+import { ResponseInterface } from '@ultras/core-api-sdk/build/types';
+import type { StatusType } from '../common';
+
+type DeletePromiseType = undefined | Promise<void | ResponseInterface>;
+
+export interface DeleteStateDataInterface<TData> {
+  status: StatusType;
+  error: null | Error;
+}
+
+export interface DeleteGroupedStateType<TData> {
+  delete: DeleteStateDataInterface<TData>;
+}
+
+export type DeleteGroupedActionType<TData> = {
+  remove(data: TData): Promise<void | null>;
+};
+
+export type DeleteGroupedInterceptorType<TData> = {
+  remove(data: Partial<TData>): DeletePromiseType;
+};

--- a/clients/app/src/stores/generateCRUD/types/store.ts
+++ b/clients/app/src/stores/generateCRUD/types/store.ts
@@ -16,15 +16,30 @@ import type {
   ListGroupedStateType,
   ListGroupedInterceptorType,
 } from './crud/list';
+import type {
+  DeleteGroupedActionType,
+  DeleteGroupedInterceptorType,
+  DeleteGroupedStateType,
+} from './crud/delete';
 
 export type RootStoreType<
-  TDataViewModel,
+  TDataList,
+  TDataSingle,
   TDataCreate,
   TDataUpdate,
+  TDataDelete,
   TKey extends StateKeyType,
   TFilter
 > = StoreApi<
-  ExtractStateAndActionType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter>
+  ExtractStateAndActionType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TKey,
+    TFilter
+  >
 >;
 
 export interface InitStoreParamsInterface<TDataViewModel> {
@@ -32,73 +47,146 @@ export interface InitStoreParamsInterface<TDataViewModel> {
   beforeSend: BeforeSendInterface<TDataViewModel>;
 }
 
-export type GroupedStateType<TDataViewModel, TDataCreate, TDataUpdate, TFilter> = {
+export type GroupedStateType<
+  TDataList,
+  TDataSingle,
+  TDataCreate,
+  TDataUpdate,
+  TDataDelete,
+  TFilter
+> = {
   add: AddGroupedStateType<TDataCreate>;
-  list: ListGroupedStateType<TDataViewModel, TFilter>;
-  single: SingleGroupedStateType<TDataViewModel>;
+  list: ListGroupedStateType<TDataList, TFilter>;
+  single: SingleGroupedStateType<TDataSingle>;
+  delete: DeleteGroupedStateType<TDataDelete>;
 };
 
-export type GroupedActionType<TDataViewModel, TDataCreate, TDataUpdate, TFilter> = {
+export type GroupedActionType<
+  TDataList,
+  TDataSingle,
+  TDataCreate,
+  TDataUpdate,
+  TDataDelete,
+  TFilter
+> = {
   add: AddGroupedActionType<TDataCreate>;
-  list: ListGroupedActionType<TDataViewModel, TFilter>;
-  single: SingleGroupedActionType<TDataViewModel>;
+  list: ListGroupedActionType<TDataList, TFilter>;
+  single: SingleGroupedActionType<TDataSingle>;
+  delete: DeleteGroupedActionType<TDataDelete>;
 };
 
-export type GroupedInterceptorType<TDataViewModel, TDataCreate, TDataUpdate, TFilter> = {
+export type GroupedInterceptorType<
+  TDataList,
+  TDataSingle,
+  TDataCreate,
+  TDataUpdate,
+  TDataDelete,
+  TFilter
+> = {
   add: AddGroupedInterceptorType<TDataCreate>;
-  list: ListGroupedInterceptorType<TDataViewModel, TFilter>;
-  single: SingleGroupedInterceptorType<TDataViewModel>;
+  list: ListGroupedInterceptorType<TDataList, TFilter>;
+  single: SingleGroupedInterceptorType<TDataSingle>;
+  delete: DeleteGroupedInterceptorType<TDataDelete>;
 };
 
 export type ExtractStateType<
-  TDataViewModel,
+  TDataList,
+  TDataSingle,
   TDataCreate,
   TDataUpdate,
+  TDataDelete,
   TStateItem extends StateKeyType,
   TFilter
 > = MergeUnion<
-  GroupedStateType<TDataViewModel, TDataCreate, TDataUpdate, TFilter>[TStateItem]
+  GroupedStateType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TFilter
+  >[TStateItem]
 >;
 
 export type ExtractActionType<
-  TDataViewModel,
+  TDataList,
+  TDataSingle,
   TDataCreate,
   TDataUpdate,
+  TDataDelete,
   TStateItem extends StateKeyType,
   TFilter
 > = MergeUnion<
-  GroupedActionType<TDataViewModel, TDataCreate, TDataUpdate, TFilter>[TStateItem]
+  GroupedActionType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TFilter
+  >[TStateItem]
 >;
 
 export type ExtractInterceptorType<
-  TDataViewModel,
+  TDataList,
+  TDataSingle,
   TDataCreate,
   TDataUpdate,
+  TDataDelete,
   TStateItem extends StateKeyType,
   TFilter
 > = MergeUnion<
-  GroupedInterceptorType<TDataViewModel, TDataCreate, TDataUpdate, TFilter>[TStateItem]
+  GroupedInterceptorType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TFilter
+  >[TStateItem]
 >;
 
 export type ExtractStateAndActionType<
-  TDataViewModel,
+  TDataList,
+  TDataSingle,
   TDataCreate,
   TDataUpdate,
+  TDataDelete,
   TStateItem extends StateKeyType,
   TFilter
-> = ExtractStateType<TDataViewModel, TDataCreate, TDataUpdate, TStateItem, TFilter> &
-  ExtractActionType<TDataViewModel, TDataCreate, TDataUpdate, TStateItem, TFilter>;
-
-export type ParamsType<
-  TDataViewModel,
+> = ExtractStateType<
+  TDataList,
+  TDataSingle,
   TDataCreate,
   TDataUpdate,
+  TDataDelete,
+  TStateItem,
+  TFilter
+> &
+  ExtractActionType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TStateItem,
+    TFilter
+  >;
+
+export type ParamsType<
+  TDataList,
+  TDataSingle,
+  TDataCreate,
+  TDataUpdate,
+  TDataDelete,
   TStateItem extends StateKeyType,
   TFilter
 > = ExtractInterceptorType<
-  TDataViewModel,
+  TDataList,
+  TDataSingle,
   TDataCreate,
   TDataUpdate,
+  TDataDelete,
   TStateItem,
   TFilter
 > & {
@@ -107,19 +195,39 @@ export type ParamsType<
 };
 
 export type StateGetterCallType<
-  TDataViewModel,
+  TDataList,
+  TDataSingle,
   TDataCreate,
   TDataUpdate,
+  TDataDelete,
   TKey extends StateKeyType,
   TFilter
-> = () => ExtractStateType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter>;
-
-export type StateSetterCallType<
-  TDataViewModel,
+> = () => ExtractStateType<
+  TDataList,
+  TDataSingle,
   TDataCreate,
   TDataUpdate,
+  TDataDelete,
+  TKey,
+  TFilter
+>;
+
+export type StateSetterCallType<
+  TDataList,
+  TDataSingle,
+  TDataCreate,
+  TDataUpdate,
+  TDataDelete,
   TKey extends StateKeyType,
   TFilter
 > = (
-  args: ExtractStateType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter>
+  args: ExtractStateType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TKey,
+    TFilter
+  >
 ) => void;

--- a/clients/app/src/stores/generateCRUD/utils/buildRootActions.ts
+++ b/clients/app/src/stores/generateCRUD/utils/buildRootActions.ts
@@ -10,30 +10,65 @@ import { fillStateKeys } from './helpers';
 import * as crudList from '../crud/list';
 import * as crudSingle from '../crud/single';
 import * as crudAdd from '../crud/add';
+import * as crudDelete from '../crud/delete';
 
 function buildRootActions<
-  TDataViewModel,
+  TDataList,
+  TDataSingle,
   TDataCreate,
   TDataUpdate,
+  TDataDelete,
   TKey extends StateKeyType,
   TFilter
 >(
-  params: ParamsType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter>,
-  storeVanilla: RootStoreType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter>
-): ExtractStateAndActionType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter> {
+  params: ParamsType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TKey,
+    TFilter
+  >,
+  storeVanilla: RootStoreType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TKey,
+    TFilter
+  >
+): ExtractStateAndActionType<
+  TDataList,
+  TDataSingle,
+  TDataCreate,
+  TDataUpdate,
+  TDataDelete,
+  TKey,
+  TFilter
+> {
   const includeKeys = fillStateKeys(params.keys || []);
 
   // @ts-ignore
-  const rootActions: ExtractActionType<TDataViewModel, TDataCreate, TDataUpdate, TKey> =
-    {};
+  const rootActions: ExtractActionType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TKey
+  > = {};
 
   if (includeKeys.list) {
     crudList.buildRootAction(
       rootActions,
       storeVanilla as RootStoreType<
-        TDataViewModel,
+        TDataList,
+        TDataSingle,
         TDataCreate,
         TDataUpdate,
+        TDataDelete,
         'list',
         TFilter
       >
@@ -44,9 +79,11 @@ function buildRootActions<
     crudSingle.buildRootAction(
       rootActions,
       storeVanilla as RootStoreType<
-        TDataViewModel,
+        TDataList,
+        TDataSingle,
         TDataCreate,
         TDataUpdate,
+        TDataDelete,
         'single',
         TFilter
       >
@@ -57,10 +94,27 @@ function buildRootActions<
     crudAdd.buildRootAction(
       rootActions,
       storeVanilla as RootStoreType<
-        TDataViewModel,
+        TDataList,
+        TDataSingle,
         TDataCreate,
         TDataUpdate,
+        TDataDelete,
         'add',
+        TFilter
+      >
+    );
+  }
+
+  if (includeKeys.delete) {
+    crudDelete.buildRootAction(
+      rootActions,
+      storeVanilla as RootStoreType<
+        TDataList,
+        TDataSingle,
+        TDataCreate,
+        TDataUpdate,
+        TDataDelete,
+        'delete',
         TFilter
       >
     );

--- a/clients/app/src/stores/generateCRUD/utils/buildStateAndActions.ts
+++ b/clients/app/src/stores/generateCRUD/utils/buildStateAndActions.ts
@@ -6,31 +6,80 @@ import { StateKeyType } from '../types/common';
 import * as crudList from '../crud/list';
 import * as crudSingle from '../crud/single';
 import * as crudAdd from '../crud/add';
+import * as crudDelete from '../crud/delete';
 
 function buildStateAndActions<
-  TDataViewModel,
+  TDataList,
+  TDataSingle,
   TDataCreate,
   TDataUpdate,
+  TDataDelete,
   TKey extends StateKeyType,
   TFilter
 >(
-  params: ParamsType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter>,
+  params: ParamsType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TKey,
+    TFilter
+  >,
   setStateCall: SetState<
-    ExtractStateAndActionType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter>
+    ExtractStateAndActionType<
+      TDataList,
+      TDataSingle,
+      TDataCreate,
+      TDataUpdate,
+      TDataDelete,
+      TKey,
+      TFilter
+    >
   >,
   getStateCall: GetState<
-    ExtractStateAndActionType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter>
+    ExtractStateAndActionType<
+      TDataList,
+      TDataSingle,
+      TDataCreate,
+      TDataUpdate,
+      TDataDelete,
+      TKey,
+      TFilter
+    >
   >
-): ExtractStateAndActionType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter> {
+): ExtractStateAndActionType<
+  TDataList,
+  TDataSingle,
+  TDataCreate,
+  TDataUpdate,
+  TDataDelete,
+  TKey,
+  TFilter
+> {
   const includeKeys = fillStateKeys(params.keys || []);
 
   const actionExtractor = makeActionExtract(params, setStateCall, getStateCall);
 
   // @ts-ignore
-  const state: ExtractStateType<TDataViewModel, TDataCreate, TDataUpdate, TKey> = {};
+  const state: ExtractStateType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TKey
+  > = {};
 
   // @ts-ignore
-  const actions: ExtractActionType<TDataViewModel, TDataCreate, TDataUpdate, TKey> = {};
+  const actions: ExtractActionType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TKey
+  > = {};
 
   if (includeKeys.list) {
     const { getState, setState, interceptors } = actionExtractor<'list'>();
@@ -53,7 +102,12 @@ function buildStateAndActions<
     crudAdd.buildActions(actions, getState, setState, interceptors);
   }
 
-  // @TODO: add delete code
+  if (includeKeys.delete) {
+    const { getState, setState, interceptors } = actionExtractor<'delete'>();
+
+    crudDelete.buildInitialState(state);
+    crudDelete.buildActions(actions, getState, setState, interceptors);
+  }
 
   // @TODO: add update code
 

--- a/clients/app/src/stores/generateCRUD/utils/helpers.ts
+++ b/clients/app/src/stores/generateCRUD/utils/helpers.ts
@@ -17,6 +17,7 @@ export function fillStateKeys(keys: Array<StateKeyType>): StateKeyParamType {
     list: true,
     single: true,
     add: true,
+    delete: true,
   };
 
   if (keys.length !== 0) {
@@ -56,40 +57,72 @@ export function buildFilterHash<T>(filter: null | FullFilterable<T>): string {
 
 // make action extractor function.
 export function makeActionExtract<
-  TDataViewModel,
+  TDataList,
+  TDataSingle,
   TDataCreate,
   TDataUpdate,
+  TDataDelete,
   TKey extends StateKeyType,
   TFilter
 >(
-  params: ParamsType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter>,
+  params: ParamsType<
+    TDataList,
+    TDataSingle,
+    TDataCreate,
+    TDataUpdate,
+    TDataDelete,
+    TKey,
+    TFilter
+  >,
   setStateCall: SetState<
-    ExtractStateAndActionType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter>
+    ExtractStateAndActionType<
+      TDataList,
+      TDataSingle,
+      TDataCreate,
+      TDataUpdate,
+      TDataDelete,
+      TKey,
+      TFilter
+    >
   >,
   getStateCall: GetState<
-    ExtractStateAndActionType<TDataViewModel, TDataCreate, TDataUpdate, TKey, TFilter>
+    ExtractStateAndActionType<
+      TDataList,
+      TDataSingle,
+      TDataCreate,
+      TDataUpdate,
+      TDataDelete,
+      TKey,
+      TFilter
+    >
   >
 ) {
   // extract params and make get/set state group based.
   return function <TStateGroup extends StateKeyType>() {
     const getState = getStateCall as StateGetterCallType<
-      TDataViewModel,
+      TDataList,
+      TDataSingle,
       TDataCreate,
       TDataUpdate,
+      TDataDelete,
       TStateGroup,
       TFilter
     >;
     const setState = setStateCall as StateSetterCallType<
-      TDataViewModel,
+      TDataList,
+      TDataSingle,
       TDataCreate,
       TDataUpdate,
+      TDataDelete,
       TStateGroup,
       TFilter
     >;
     const interceptors = params as ExtractInterceptorType<
-      TDataViewModel,
+      TDataList,
+      TDataSingle,
       TDataCreate,
       TDataUpdate,
+      TDataDelete,
       TStateGroup,
       TFilter
     >;

--- a/clients/app/src/stores/matches.ts
+++ b/clients/app/src/stores/matches.ts
@@ -18,7 +18,15 @@ type FilterType = Filterable<GetMatchesFilter>;
 const sdk = new MatchSDK('dev');
 
 const buildMatchesStore = (params: Partial<ParamType> = {}) => {
-  return generateCRUD<MatchViewModel, null, null, FilterType, 'list' | 'single'>({
+  return generateCRUD<
+    MatchViewModel,
+    MatchViewModel,
+    null,
+    null,
+    ResourceIdentifier,
+    FilterType,
+    'list' | 'single'
+  >({
     keys: ['list', 'single'],
     ...(params as ParamType),
 

--- a/clients/app/src/stores/teams.ts
+++ b/clients/app/src/stores/teams.ts
@@ -21,6 +21,8 @@ const buildTeamsStore = (params: Partial<ParamType> = {}) => {
     TeamViewModel,
     TeamViewModel,
     TeamViewModel,
+    TeamViewModel,
+    ResourceIdentifier,
     FilterType,
     'list' | 'single'
   >({

--- a/clients/app/src/views/screens/Team/components/TeamComponent.tsx
+++ b/clients/app/src/views/screens/Team/components/TeamComponent.tsx
@@ -4,10 +4,12 @@ import I18n from 'i18n/i18n';
 import { useTheme } from 'themes';
 import { Divider, Circle, Image, Text } from 'native-base';
 import authenticationStore, { IState } from 'stores/authentication';
+import buildFavoriteTeamsStore from 'stores/favoriteTeams';
 import { TeamTypesEnum } from '@ultras/utils';
 import { ITeamComponentProps } from '../types';
 
 const useAuthenticationStore = authenticationStore.initStore();
+const favoriteTeamsStore = buildFavoriteTeamsStore();
 
 const TeamComponent: React.FC<ITeamComponentProps> = ({ data }) => {
   const { colors } = useTheme();
@@ -19,6 +21,20 @@ const TeamComponent: React.FC<ITeamComponentProps> = ({ data }) => {
   const isFavorite = React.useMemo(
     () => user.teams.indexOf(data.id) !== -1,
     [data.id, user.teams]
+  );
+
+  const onUpdateTeamsPress = React.useCallback(
+    (teamId: ResourceIdentifier) => {
+      if (isFavorite) {
+        favoriteTeamsStore.remove({ teamId });
+      } else {
+        favoriteTeamsStore.setFieldValue('teamId', teamId);
+        favoriteTeamsStore.create();
+      }
+
+      updateTeams(teamId);
+    },
+    [isFavorite, updateTeams]
   );
 
   return (
@@ -45,7 +61,7 @@ const TeamComponent: React.FC<ITeamComponentProps> = ({ data }) => {
           </Text>
 
           <Button
-            onPress={() => updateTeams(data.id)}
+            onPress={() => onUpdateTeamsPress(data.id)}
             variant={isFavorite ? 'actionInvert' : 'action'}
             mt={'3'}
             mr={'4'}

--- a/packages/services/NetworkService/index.ts
+++ b/packages/services/NetworkService/index.ts
@@ -99,10 +99,16 @@ class NetworkService {
   };
 
   createUrl = (arg: string) => {
+    let endpoint = '';
     if (Array.isArray(arg)) {
-      return [this.uri, ...arg].join('/');
+      // join arguments via slash
+      endpoint = [this.uri, ...arg].join('/');
+    } else {
+      // remove first slash
+      endpoint = arg.replace(/^\//, '');
     }
-    return `${this.uri}/${arg}`;
+
+    return `${this.uri}/${endpoint}`;
   };
 
   createQueryParams = (queryParams: Record<string, unknown>) => {
@@ -224,18 +230,20 @@ class NetworkService {
         options.method = HttpRequestMethods.GET;
       }
 
-      // const auth_token = CacheService.getItem('auth_token');
       const fetchOptions: RequestInit = {
         method: options.method,
-        headers: options.headers || {
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
           Accept: 'application/json',
           'Content-Type': 'application/json',
-          // Authorization: auth_token ? `Bearer ${auth_token}` : null,
         },
       };
 
-      if (options.headers) {
-        fetchOptions.headers = options.headers;
+      if (options.headers && typeof options.headers === 'object') {
+        fetchOptions.headers = {
+          ...fetchOptions.headers,
+          ...options.headers,
+        };
       }
 
       try {

--- a/sdks/core-api-sdk/src/sdks/FavoriteTeamSDK/index.ts
+++ b/sdks/core-api-sdk/src/sdks/FavoriteTeamSDK/index.ts
@@ -43,4 +43,8 @@ export class FavoriteTeamSDK extends CoreApiBaseSDK {
   public remove(id: ResourceIdentifier) {
     return this.api?.makeAPIDeleteRequest(`/${id}`);
   }
+
+  public removeByTeamId(id: ResourceIdentifier) {
+    return this.api?.makeAPIDeleteRequest(`/teams/${id}`);
+  }
 }


### PR DESCRIPTION
This PR includes:
1) `DELETE` functionality added into `Generate CRUD`.
2) Delete favorite team store logic implemented.
3) Network service headers bug fixed.
4) Remove favorite team by `teamId` added.