### PR TITLE
[refactor] all interfaces are renamed from '*Interface' to 'I*'

### DIFF
--- a/.aws/s3-lambda/lambda/source/app.ts
+++ b/.aws/s3-lambda/lambda/source/app.ts
@@ -1,7 +1,7 @@
 import handleImages from './lib/handle';
 import respond from './lib/respond';
 
-export const handler = async (event: EventInterface, context: ContextInterface) => {
+export const handler = async (event: IEvent, context: IContext) => {
   try {
     await handleImages(event, context);
 

--- a/.aws/s3-lambda/lambda/source/configs.ts
+++ b/.aws/s3-lambda/lambda/source/configs.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 
-interface SizeInterface {
+interface ISize {
   width: number;
   height: number;
 }
@@ -11,7 +11,7 @@ export const paths: Record<string, string> = {
   original: 'original',
 };
 
-export const sizes: Array<SizeInterface> = [
+export const sizes: Array<ISize> = [
   {
     width: 256,
     height: 256,

--- a/.aws/s3-lambda/lambda/source/index.d.ts
+++ b/.aws/s3-lambda/lambda/source/index.d.ts
@@ -1,4 +1,4 @@
-declare interface RecordInterface {
+declare interface IRecord {
   eventVersion: string;
   eventSource: string;
   awsRegion: string;
@@ -30,15 +30,15 @@ declare interface RecordInterface {
   };
 }
 
-declare interface EventInterface {
-  Records: Array<RecordInterface>;
+declare interface IEvent {
+  Records: Array<IRecord>;
 }
 
-declare interface ContextInterface {
+declare interface IContext {
   // ...
 }
 
-declare interface LambdaResponseInterface {
+declare interface ILambdaResponse {
   isBase64Encoded?: boolean;
   statusCode: number;
   headers?: Record<string, any>;

--- a/.aws/s3-lambda/lambda/source/lib/handle.ts
+++ b/.aws/s3-lambda/lambda/source/lib/handle.ts
@@ -3,7 +3,7 @@
 import * as configs from '../configs';
 import processItem from './process';
 
-export default async function (event: EventInterface, context: ContextInterface) {
+export default async function (event: IEvent, context: IContext) {
   for (const record of event.Records) {
     try {
       const bucketName = record.s3.bucket.name;

--- a/.aws/s3-lambda/lambda/source/lib/resize.ts
+++ b/.aws/s3-lambda/lambda/source/lib/resize.ts
@@ -1,14 +1,14 @@
 import { Body } from 'aws-sdk/clients/s3';
 import sharp from 'sharp';
 
-interface ParamsInterface {
+interface ParamsI {
   body?: Body;
   format: 'png' | 'jpeg';
   width: number;
   height: number;
 }
 
-async function resize(params: ParamsInterface): Promise<Body | null> {
+async function resize(params: ParamsI): Promise<Body | null> {
   if (!params.body) {
     return null;
   }

--- a/.aws/s3-lambda/lambda/source/lib/respond.ts
+++ b/.aws/s3-lambda/lambda/source/lib/respond.ts
@@ -1,4 +1,4 @@
-function respond(statusCode: number, data: any): LambdaResponseInterface {
+function respond(statusCode: number, data: any): ILambdaResponse {
   return {
     statusCode: statusCode,
     body: JSON.stringify(data),

--- a/apis/core-api/src/api/middlewares/parse-auth-token/index.ts
+++ b/apis/core-api/src/api/middlewares/parse-auth-token/index.ts
@@ -1,9 +1,9 @@
 import { Middleware, Next as KoaNext } from 'koa';
 import { Context } from 'types';
 import { AuthService } from 'core/services';
-import { AuthTokenResultInterface } from 'core/services/AuthService';
+import { IAuthTokenResult } from 'core/services/AuthService';
 
-interface OptionsInterface {
+interface IOptions {
   regenerateOnExpire?: boolean;
 }
 
@@ -22,7 +22,7 @@ const getAuthToken = (ctx: Context): null | string => {
 /**
  * Set new auth token into context.
  */
-const updateAuthTokenHeader = (ctx: Context, newAuthToken: AuthTokenResultInterface) => {
+const updateAuthTokenHeader = (ctx: Context, newAuthToken: IAuthTokenResult) => {
   ctx.set('X-New-AuthToken', newAuthToken.authToken);
   ctx.newAuthToken = newAuthToken;
 
@@ -56,7 +56,7 @@ const isExpired = (authToken: string) => {
 const updateTokenIfExpired = async (
   ctx: Context,
   authToken: string
-): Promise<AuthTokenResultInterface | null> => {
+): Promise<IAuthTokenResult | null> => {
   if (!isExpired(authToken)) {
     return null;
   }
@@ -96,7 +96,7 @@ const callNextFunc = async (ctx: Context, next: KoaNext, authToken: string) => {
   return next();
 };
 
-export default (options?: OptionsInterface): Middleware => {
+export default (options?: IOptions): Middleware => {
   return async (ctx: Context, next: KoaNext) => {
     // if auth token is not provided by authorization header
     // then we need to skip this middleware action.

--- a/apis/core-api/src/api/middlewares/rate-limit/index.ts
+++ b/apis/core-api/src/api/middlewares/rate-limit/index.ts
@@ -3,7 +3,7 @@ import rateLimit from 'koa-ratelimit';
 import { Context } from 'types';
 import { RedisService } from 'core/services';
 
-interface OptionsInterface {
+interface IOptions {
   seconds: number;
   requests: number;
 }
@@ -16,7 +16,7 @@ const getClientFingerprint = (ctx: Context): string => {
   return ctx.ip + ' @@ ' + ctx.device.fingerprint;
 };
 
-export default (options: OptionsInterface): Middleware => {
+export default (options: IOptions): Middleware => {
   options.seconds = options.seconds || 60;
   options.requests = options.requests || 20;
 

--- a/apis/core-api/src/api/routes/v1/fanClubs/middlewares/validateFanClubMembership.ts
+++ b/apis/core-api/src/api/routes/v1/fanClubs/middlewares/validateFanClubMembership.ts
@@ -8,12 +8,12 @@ import { Context } from 'types';
 import { FanClubMemberService, FanClubService } from 'core/services';
 import { AccessDeniedError, ResourceNotFoundError } from 'modules/exceptions';
 
-interface ValidationInterface {
+interface IValidation {
   statuses?: FanClubMemberStatusEnum | Array<FanClubMemberStatusEnum>;
   roles?: FanClubMemberRoleEnum | Array<FanClubMemberRoleEnum>;
 }
 
-export default (validation: ValidationInterface, routeIdParamName = 'id'): Middleware => {
+export default (validation: IValidation, routeIdParamName = 'id'): Middleware => {
   return async (ctx: Context, next: KoaNext) => {
     const fanClubId = ctx.request.params[routeIdParamName];
     const fanClub = await FanClubService.getById(fanClubId);

--- a/apis/core-api/src/core/controllers/CityController/types.ts
+++ b/apis/core-api/src/core/controllers/CityController/types.ts
@@ -7,12 +7,12 @@ import {
   ResourceIdentifier,
 } from 'types';
 
-interface CitiesFilterInterface {
+interface ICitiesFilter {
   name?: string;
   countryId?: ResourceIdentifier;
 }
 
-export type CitiesListParams = ControllerListParamsType<CitiesFilterInterface>;
+export type CitiesListParams = ControllerListParamsType<ICitiesFilter>;
 export type CitiesListResult = ControllerListResultType<CitiesViewModel>;
 export type CityByIdResult = ControllerByIdResultType<CityViewModel>;
 export type CitiesInjectDataResult = ControllerInjectionResultType;

--- a/apis/core-api/src/core/controllers/CountryController/types.ts
+++ b/apis/core-api/src/core/controllers/CountryController/types.ts
@@ -6,12 +6,12 @@ import {
   ControllerInjectionResultType,
 } from 'types';
 
-interface CountriesFilterInterface {
+interface ICountriesFilter {
   name?: string;
   code?: string;
 }
 
-export type CountriesListParams = ControllerListParamsType<CountriesFilterInterface>;
+export type CountriesListParams = ControllerListParamsType<ICountriesFilter>;
 export type CountriesListResult = ControllerListResultType<CountriesViewModel>;
 export type CountryByIdResult = ControllerByIdResultType<CountryViewModel>;
 export type CountriesInjectDataResult = ControllerInjectionResultType;

--- a/apis/core-api/src/core/controllers/EventCommentController/EventCommentController.ts
+++ b/apis/core-api/src/core/controllers/EventCommentController/EventCommentController.ts
@@ -7,16 +7,16 @@ import { DEFAULT_PAGINATION_ATTRIBUTES } from '@constants';
 import type {
   CommentsListParams,
   CommentListResult,
-  CommentCreateParamsInterface,
-  CommentUpdateParamsInterface,
-  CommentDeleteParamsInterface,
+  ICommentCreateParams,
+  ICommentUpdateParams,
+  ICommentDeleteParams,
 } from './types';
 
 class EventCommentController extends BaseController {
   /**
    * Add comment under event.
    */
-  static async create({ userId, eventId, content }: CommentCreateParamsInterface) {
+  static async create({ userId, eventId, content }: ICommentCreateParams) {
     // get event model
     const event = await EventService.getById({ id: eventId }, false);
     if (!event) {
@@ -39,12 +39,7 @@ class EventCommentController extends BaseController {
   /**
    * Update comment under event.
    */
-  static async update({
-    userId,
-    eventId,
-    commentId,
-    content,
-  }: CommentUpdateParamsInterface) {
+  static async update({ userId, eventId, commentId, content }: ICommentUpdateParams) {
     // get event model
     const event = await EventService.getById({ id: eventId }, false);
     if (!event) {
@@ -68,7 +63,7 @@ class EventCommentController extends BaseController {
   /**
    * Make event un-liked by user.
    */
-  static async delete({ userId, eventId, commentId }: CommentDeleteParamsInterface) {
+  static async delete({ userId, eventId, commentId }: ICommentDeleteParams) {
     // get event model
     const event = await EventService.getById({ id: eventId }, false);
     if (!event) {

--- a/apis/core-api/src/core/controllers/EventCommentController/types.ts
+++ b/apis/core-api/src/core/controllers/EventCommentController/types.ts
@@ -1,26 +1,26 @@
 import type { UserViewModel } from '@ultras/view-models';
 import type { ControllerListParamsType, ControllerListResultType } from 'types';
 
-export interface CommentsFilterInterface {
+export interface ICommentsFilter {
   eventId: ResourceIdentifier;
 }
 
-export interface CommentCreateParamsInterface {
+export interface ICommentCreateParams {
   userId: ResourceIdentifier;
   eventId: ResourceIdentifier;
   content: string;
 }
-export interface CommentUpdateParamsInterface {
+export interface ICommentUpdateParams {
   userId: ResourceIdentifier;
   eventId: ResourceIdentifier;
   commentId: ResourceIdentifier;
   content: string;
 }
-export interface CommentDeleteParamsInterface {
+export interface ICommentDeleteParams {
   userId: ResourceIdentifier;
   eventId: ResourceIdentifier;
   commentId: ResourceIdentifier;
 }
 
-export type CommentsListParams = ControllerListParamsType<CommentsFilterInterface>;
+export type CommentsListParams = ControllerListParamsType<ICommentsFilter>;
 export type CommentListResult = ControllerListResultType<UserViewModel>;

--- a/apis/core-api/src/core/controllers/EventController/types.ts
+++ b/apis/core-api/src/core/controllers/EventController/types.ts
@@ -9,7 +9,7 @@ import {
   ResourceIdentifier,
 } from 'types';
 
-interface EventsFilterInterface {
+interface IEventsFilter {
   userId: ResourceIdentifier;
   search?: string;
   fanClubId?: ResourceIdentifier;
@@ -52,7 +52,7 @@ export type EventDeleteParams = {
 export type EventCreateResult = ControllerResultType<EventViewModel>;
 export type EventUpdateResult = ControllerResultType<EventViewModel>;
 
-export type EventsListParams = ControllerListParamsType<EventsFilterInterface>;
+export type EventsListParams = ControllerListParamsType<IEventsFilter>;
 export type EventsListResult = ControllerListResultType<EventViewModel>;
 export type EventByIdParams = {
   id: ResourceIdentifier;

--- a/apis/core-api/src/core/controllers/EventLikeController/EventLikeController.ts
+++ b/apis/core-api/src/core/controllers/EventLikeController/EventLikeController.ts
@@ -4,13 +4,13 @@ import { EventService, LikeService } from 'core/services';
 import { ResourceNotFoundError } from 'modules/exceptions';
 
 import { DEFAULT_PAGINATION_ATTRIBUTES } from '@constants';
-import type { LikesListParams, LikeListResult, LikeUnlikeParamsInterface } from './types';
+import type { LikesListParams, LikeListResult, ILikeUnlikeParams } from './types';
 
 class EventLikeController extends BaseController {
   /**
    * Make event liked by user.
    */
-  static async create({ userId, eventId }: LikeUnlikeParamsInterface) {
+  static async create({ userId, eventId }: ILikeUnlikeParams) {
     // get event model
     const event = await EventService.getById({ id: eventId }, false);
     if (!event) {
@@ -30,7 +30,7 @@ class EventLikeController extends BaseController {
   /**
    * Make event un-liked by user.
    */
-  static async delete({ userId, eventId }: LikeUnlikeParamsInterface) {
+  static async delete({ userId, eventId }: ILikeUnlikeParams) {
     // get event model
     const event = await EventService.getById({ id: eventId }, false);
     if (!event) {

--- a/apis/core-api/src/core/controllers/EventLikeController/types.ts
+++ b/apis/core-api/src/core/controllers/EventLikeController/types.ts
@@ -1,14 +1,14 @@
 import type { UserViewModel } from '@ultras/view-models';
 import type { ControllerListParamsType, ControllerListResultType } from 'types';
 
-export interface LikesFilterInterface {
+export interface ILikesFilter {
   eventId: ResourceIdentifier;
 }
 
-export interface LikeUnlikeParamsInterface {
+export interface ILikeUnlikeParams {
   userId: ResourceIdentifier;
   eventId: ResourceIdentifier;
 }
 
-export type LikesListParams = ControllerListParamsType<LikesFilterInterface>;
+export type LikesListParams = ControllerListParamsType<ILikesFilter>;
 export type LikeListResult = ControllerListResultType<UserViewModel>;

--- a/apis/core-api/src/core/controllers/EventMemberController/types.ts
+++ b/apis/core-api/src/core/controllers/EventMemberController/types.ts
@@ -8,7 +8,7 @@ import {
   ResourceIdentifier,
 } from 'types';
 
-interface EventMembersFilterInterface {
+interface IEventMembersFilter {
   search?: string;
   eventId: ResourceIdentifier;
 }
@@ -25,6 +25,5 @@ export type EventMemberDeleteParams = {
 
 export type EventMemberCreateResult = ControllerResultType<EventViewModel>;
 
-export type EventMembersListParams =
-  ControllerListParamsType<EventMembersFilterInterface>;
+export type EventMembersListParams = ControllerListParamsType<IEventMembersFilter>;
 export type EventMembersListResult = ControllerListResultType<EventViewModel>;

--- a/apis/core-api/src/core/controllers/FanClubController/types.ts
+++ b/apis/core-api/src/core/controllers/FanClubController/types.ts
@@ -9,7 +9,7 @@ import {
 } from 'types';
 import { FanClubAttributes } from 'core/data/models/FanClub';
 
-interface FanClubsFilterInterface {
+interface IFanClubsFilter {
   name?: string;
   countryId?: ResourceIdentifier;
   cityId?: ResourceIdentifier;
@@ -48,7 +48,7 @@ export type FanClubUpdateResult = ControllerResultType<{
   fanClub?: FanClubAttributes;
 }>;
 
-export type FanClubsListParams = ControllerListParamsType<FanClubsFilterInterface>;
+export type FanClubsListParams = ControllerListParamsType<IFanClubsFilter>;
 export type FanClubsListResult = ControllerListResultType<FanClubAttributes>;
 export type FanClubByIdResult = ControllerByIdResultType<FanClubAttributes>;
 export type FanClubsInjectDataResult = ControllerInjectionResultType;

--- a/apis/core-api/src/core/controllers/FanClubMembershipController/types.ts
+++ b/apis/core-api/src/core/controllers/FanClubMembershipController/types.ts
@@ -8,17 +8,17 @@ import {
   ResourceIdentifier,
 } from 'types';
 
-interface FanClubFilterInterface {
+interface IFanClubFilter {
   search?: string;
   roleId?: ResourceIdentifier;
   status?: FanClubMemberStatusEnum;
 }
 
-interface FanClubMembershipsFilterInterface extends FanClubFilterInterface {
+interface IFanClubMembershipsFilter extends IFanClubFilter {
   fanClubId: ResourceIdentifier;
 }
 
-interface FanClubMembershipsByMemberIdInterface extends FanClubFilterInterface {
+interface IFanClubMembershipsByMemberId extends IFanClubFilter {
   memberId: ResourceIdentifier;
 }
 
@@ -104,11 +104,11 @@ export type FanClubMembershipByIdResult =
   ControllerByIdResultType<FanClubMemberViewModel>;
 
 export type FanClubMembershipsListParams =
-  ControllerListParamsType<FanClubMembershipsFilterInterface>;
+  ControllerListParamsType<IFanClubMembershipsFilter>;
 export type FanClubMembershipsListResult =
   ControllerListResultType<FanClubMemberViewModel>;
 
 export type FanClubMembershipsByMemberIdListParams =
-  ControllerListParamsType<FanClubMembershipsByMemberIdInterface>;
+  ControllerListParamsType<IFanClubMembershipsByMemberId>;
 export type FanClubMembershipsByMemberIdListResult =
   ControllerListResultType<FanClubMemberViewModel>;

--- a/apis/core-api/src/core/controllers/LeagueController/types.ts
+++ b/apis/core-api/src/core/controllers/LeagueController/types.ts
@@ -7,12 +7,12 @@ import {
   ResourceIdentifier,
 } from 'types';
 
-interface LeaguesFilterInterface {
+interface ILeaguesFilter {
   name?: string;
   countryId?: ResourceIdentifier;
 }
 
-export type LeaguesListParams = ControllerListParamsType<LeaguesFilterInterface>;
+export type LeaguesListParams = ControllerListParamsType<ILeaguesFilter>;
 export type LeaguesListResult = ControllerListResultType<LeaguesViewModel>;
 export type LeagueByIdResult = ControllerByIdResultType<LeagueViewModel>;
 export type LeaguesInjectDataResult = ControllerInjectionResultType;

--- a/apis/core-api/src/core/controllers/MatchCommentController/MatchCommentController.ts
+++ b/apis/core-api/src/core/controllers/MatchCommentController/MatchCommentController.ts
@@ -7,16 +7,16 @@ import { DEFAULT_PAGINATION_ATTRIBUTES } from '@constants';
 import type {
   CommentsListParams,
   CommentListResult,
-  CommentCreateParamsInterface,
-  CommentUpdateParamsInterface,
-  CommentDeleteParamsInterface,
+  ICommentCreateParams,
+  ICommentUpdateParams,
+  ICommentDeleteParams,
 } from './types';
 
 class MatchCommentController extends BaseController {
   /**
    * Add comment under match.
    */
-  static async create({ userId, matchId, content }: CommentCreateParamsInterface) {
+  static async create({ userId, matchId, content }: ICommentCreateParams) {
     // get match model
     const match = await MatchService.getById(matchId);
     if (!match) {
@@ -39,12 +39,7 @@ class MatchCommentController extends BaseController {
   /**
    * Update comment under match.
    */
-  static async update({
-    userId,
-    matchId,
-    commentId,
-    content,
-  }: CommentUpdateParamsInterface) {
+  static async update({ userId, matchId, commentId, content }: ICommentUpdateParams) {
     // get match model
     const match = await MatchService.getById(matchId);
     if (!match) {
@@ -68,7 +63,7 @@ class MatchCommentController extends BaseController {
   /**
    * Make match un-liked by user.
    */
-  static async delete({ userId, matchId, commentId }: CommentDeleteParamsInterface) {
+  static async delete({ userId, matchId, commentId }: ICommentDeleteParams) {
     // get match model
     const match = await MatchService.getById(matchId);
     if (!match) {

--- a/apis/core-api/src/core/controllers/MatchCommentController/types.ts
+++ b/apis/core-api/src/core/controllers/MatchCommentController/types.ts
@@ -1,26 +1,26 @@
 import type { UserViewModel } from '@ultras/view-models';
 import type { ControllerListParamsType, ControllerListResultType } from 'types';
 
-export interface CommentsFilterInterface {
+export interface ICommentsFilter {
   matchId: ResourceIdentifier;
 }
 
-export interface CommentCreateParamsInterface {
+export interface ICommentCreateParams {
   userId: ResourceIdentifier;
   matchId: ResourceIdentifier;
   content: string;
 }
-export interface CommentUpdateParamsInterface {
+export interface ICommentUpdateParams {
   userId: ResourceIdentifier;
   matchId: ResourceIdentifier;
   commentId: ResourceIdentifier;
   content: string;
 }
-export interface CommentDeleteParamsInterface {
+export interface ICommentDeleteParams {
   userId: ResourceIdentifier;
   matchId: ResourceIdentifier;
   commentId: ResourceIdentifier;
 }
 
-export type CommentsListParams = ControllerListParamsType<CommentsFilterInterface>;
+export type CommentsListParams = ControllerListParamsType<ICommentsFilter>;
 export type CommentListResult = ControllerListResultType<UserViewModel>;

--- a/apis/core-api/src/core/controllers/MatchController/types.ts
+++ b/apis/core-api/src/core/controllers/MatchController/types.ts
@@ -7,7 +7,7 @@ import {
   ResourceIdentifier,
 } from 'types';
 
-interface MatchesFilterInterface {
+interface IMatchesFilter {
   search?: string;
   dateFrom?: string;
   dateTo?: string;
@@ -18,7 +18,7 @@ interface MatchesFilterInterface {
   teamAwayId?: ResourceIdentifier;
 }
 
-export type MatchesListParams = ControllerListParamsType<MatchesFilterInterface>;
+export type MatchesListParams = ControllerListParamsType<IMatchesFilter>;
 export type MatchesListResult = ControllerListResultType<MatchesViewModel>;
 export type MatchByIdResult = ControllerByIdResultType<MatchViewModel>;
 export type MatchesInjectDataResult = ControllerInjectionResultType;

--- a/apis/core-api/src/core/controllers/MatchLikeController/MatchLikeController.ts
+++ b/apis/core-api/src/core/controllers/MatchLikeController/MatchLikeController.ts
@@ -4,13 +4,13 @@ import { MatchService, LikeService } from 'core/services';
 import { ResourceNotFoundError } from 'modules/exceptions';
 
 import { DEFAULT_PAGINATION_ATTRIBUTES } from '@constants';
-import type { LikesListParams, LikeListResult, LikeUnlikeParamsInterface } from './types';
+import type { LikesListParams, LikeListResult, ILikeUnlikeParams } from './types';
 
 class MatchLikeController extends BaseController {
   /**
    * Make match liked by user.
    */
-  static async create({ userId, matchId }: LikeUnlikeParamsInterface) {
+  static async create({ userId, matchId }: ILikeUnlikeParams) {
     // get match model
     const match = await MatchService.getById(matchId);
     if (!match) {
@@ -30,7 +30,7 @@ class MatchLikeController extends BaseController {
   /**
    * Make match un-liked by user.
    */
-  static async delete({ userId, matchId }: LikeUnlikeParamsInterface) {
+  static async delete({ userId, matchId }: ILikeUnlikeParams) {
     // get match model
     const match = await MatchService.getById(matchId);
     if (!match) {

--- a/apis/core-api/src/core/controllers/MatchLikeController/types.ts
+++ b/apis/core-api/src/core/controllers/MatchLikeController/types.ts
@@ -1,14 +1,14 @@
 import type { UserViewModel } from '@ultras/view-models';
 import type { ControllerListParamsType, ControllerListResultType } from 'types';
 
-export interface LikesFilterInterface {
+export interface ILikesFilter {
   matchId: ResourceIdentifier;
 }
 
-export interface LikeUnlikeParamsInterface {
+export interface ILikeUnlikeParams {
   userId: ResourceIdentifier;
   matchId: ResourceIdentifier;
 }
 
-export type LikesListParams = ControllerListParamsType<LikesFilterInterface>;
+export type LikesListParams = ControllerListParamsType<ILikesFilter>;
 export type LikeListResult = ControllerListResultType<UserViewModel>;

--- a/apis/core-api/src/core/controllers/RoomCommentController/RoomCommentController.ts
+++ b/apis/core-api/src/core/controllers/RoomCommentController/RoomCommentController.ts
@@ -7,16 +7,16 @@ import { DEFAULT_PAGINATION_ATTRIBUTES } from '@constants';
 import type {
   CommentsListParams,
   CommentListResult,
-  CommentCreateParamsInterface,
-  CommentUpdateParamsInterface,
-  CommentDeleteParamsInterface,
+  ICommentCreateParams,
+  ICommentUpdateParams,
+  ICommentDeleteParams,
 } from './types';
 
 class RoomCommentController extends BaseController {
   /**
    * Add comment under room.
    */
-  static async create({ userId, roomId, content }: CommentCreateParamsInterface) {
+  static async create({ userId, roomId, content }: ICommentCreateParams) {
     // get room model
     const room = await RoomService.getById({ id: roomId }, false);
     if (!room) {
@@ -39,12 +39,7 @@ class RoomCommentController extends BaseController {
   /**
    * Update comment under room.
    */
-  static async update({
-    userId,
-    roomId,
-    commentId,
-    content,
-  }: CommentUpdateParamsInterface) {
+  static async update({ userId, roomId, commentId, content }: ICommentUpdateParams) {
     // get room model
     const room = await RoomService.getById({ id: roomId }, false);
     if (!room) {
@@ -68,7 +63,7 @@ class RoomCommentController extends BaseController {
   /**
    * Make room un-liked by user.
    */
-  static async delete({ userId, roomId, commentId }: CommentDeleteParamsInterface) {
+  static async delete({ userId, roomId, commentId }: ICommentDeleteParams) {
     // get room model
     const room = await RoomService.getById({ id: roomId }, false);
     if (!room) {

--- a/apis/core-api/src/core/controllers/RoomCommentController/types.ts
+++ b/apis/core-api/src/core/controllers/RoomCommentController/types.ts
@@ -1,26 +1,26 @@
 import type { UserViewModel } from '@ultras/view-models';
 import type { ControllerListParamsType, ControllerListResultType } from 'types';
 
-export interface CommentsFilterInterface {
+export interface ICommentsFilter {
   roomId: ResourceIdentifier;
 }
 
-export interface CommentCreateParamsInterface {
+export interface ICommentCreateParams {
   userId: ResourceIdentifier;
   roomId: ResourceIdentifier;
   content: string;
 }
-export interface CommentUpdateParamsInterface {
+export interface ICommentUpdateParams {
   userId: ResourceIdentifier;
   roomId: ResourceIdentifier;
   commentId: ResourceIdentifier;
   content: string;
 }
-export interface CommentDeleteParamsInterface {
+export interface ICommentDeleteParams {
   userId: ResourceIdentifier;
   roomId: ResourceIdentifier;
   commentId: ResourceIdentifier;
 }
 
-export type CommentsListParams = ControllerListParamsType<CommentsFilterInterface>;
+export type CommentsListParams = ControllerListParamsType<ICommentsFilter>;
 export type CommentListResult = ControllerListResultType<UserViewModel>;

--- a/apis/core-api/src/core/controllers/RoomController/types.ts
+++ b/apis/core-api/src/core/controllers/RoomController/types.ts
@@ -9,7 +9,7 @@ import {
   ResourceIdentifier,
 } from 'types';
 
-interface RoomsFilterInterface {
+interface IRoomsFilter {
   userId: ResourceIdentifier;
   search?: string;
   fanClubId?: ResourceIdentifier;
@@ -42,7 +42,7 @@ export type RoomDeleteParams = {
 export type RoomCreateResult = ControllerResultType<RoomViewModel>;
 export type RoomUpdateResult = ControllerResultType<RoomViewModel>;
 
-export type RoomsListParams = ControllerListParamsType<RoomsFilterInterface>;
+export type RoomsListParams = ControllerListParamsType<IRoomsFilter>;
 export type RoomsListResult = ControllerListResultType<RoomViewModel>;
 export type RoomByIdParams = {
   id: ResourceIdentifier;

--- a/apis/core-api/src/core/controllers/RoomLikeController/RoomLikeController.ts
+++ b/apis/core-api/src/core/controllers/RoomLikeController/RoomLikeController.ts
@@ -4,13 +4,13 @@ import { RoomService, LikeService } from 'core/services';
 import { ResourceNotFoundError } from 'modules/exceptions';
 
 import { DEFAULT_PAGINATION_ATTRIBUTES } from '@constants';
-import type { LikesListParams, LikeListResult, LikeUnlikeParamsInterface } from './types';
+import type { LikesListParams, LikeListResult, ILikeUnlikeParams } from './types';
 
 class RoomLikeController extends BaseController {
   /**
    * Make room liked by user.
    */
-  static async create({ userId, roomId }: LikeUnlikeParamsInterface) {
+  static async create({ userId, roomId }: ILikeUnlikeParams) {
     // get room model
     const room = await RoomService.getById({ id: roomId }, false);
     if (!room) {
@@ -30,7 +30,7 @@ class RoomLikeController extends BaseController {
   /**
    * Make room un-liked by user.
    */
-  static async delete({ userId, roomId }: LikeUnlikeParamsInterface) {
+  static async delete({ userId, roomId }: ILikeUnlikeParams) {
     // get room model
     const room = await RoomService.getById({ id: roomId }, false);
     if (!room) {

--- a/apis/core-api/src/core/controllers/RoomLikeController/types.ts
+++ b/apis/core-api/src/core/controllers/RoomLikeController/types.ts
@@ -1,14 +1,14 @@
 import type { UserViewModel } from '@ultras/view-models';
 import type { ControllerListParamsType, ControllerListResultType } from 'types';
 
-export interface LikesFilterInterface {
+export interface ILikesFilter {
   roomId: ResourceIdentifier;
 }
 
-export interface LikeUnlikeParamsInterface {
+export interface ILikeUnlikeParams {
   userId: ResourceIdentifier;
   roomId: ResourceIdentifier;
 }
 
-export type LikesListParams = ControllerListParamsType<LikesFilterInterface>;
+export type LikesListParams = ControllerListParamsType<ILikesFilter>;
 export type LikeListResult = ControllerListResultType<UserViewModel>;

--- a/apis/core-api/src/core/controllers/RoomMemberController/types.ts
+++ b/apis/core-api/src/core/controllers/RoomMemberController/types.ts
@@ -8,7 +8,7 @@ import {
   ResourceIdentifier,
 } from 'types';
 
-interface RoomMembersFilterInterface {
+interface IRoomMembersFilter {
   search?: string;
   roomId: ResourceIdentifier;
 }
@@ -25,5 +25,5 @@ export type RoomMemberDeleteParams = {
 
 export type RoomMemberCreateResult = ControllerResultType<RoomViewModel>;
 
-export type RoomMembersListParams = ControllerListParamsType<RoomMembersFilterInterface>;
+export type RoomMembersListParams = ControllerListParamsType<IRoomMembersFilter>;
 export type RoomMembersListResult = ControllerListResultType<RoomViewModel>;

--- a/apis/core-api/src/core/controllers/TeamController/types.ts
+++ b/apis/core-api/src/core/controllers/TeamController/types.ts
@@ -8,7 +8,7 @@ import {
   ResourceIdentifier,
 } from 'types';
 
-interface TeamsFilterInterface {
+interface ITeamsFilter {
   name?: string;
   countryId?: ResourceIdentifier;
   cityId?: ResourceIdentifier;
@@ -16,7 +16,7 @@ interface TeamsFilterInterface {
   type?: TeamTypesEnum;
 }
 
-export type TeamsListParams = ControllerListParamsType<TeamsFilterInterface>;
+export type TeamsListParams = ControllerListParamsType<ITeamsFilter>;
 export type TeamsListResult = ControllerListResultType<TeamsViewModel>;
 export type TeamByIdResult = ControllerByIdResultType<TeamViewModel>;
 export type TeamsInjectDataResult = ControllerInjectionResultType;

--- a/apis/core-api/src/core/controllers/VenueController/types.ts
+++ b/apis/core-api/src/core/controllers/VenueController/types.ts
@@ -7,13 +7,13 @@ import {
   ResourceIdentifier,
 } from 'types';
 
-interface VenuesFilterInterface {
+interface IVenuesFilter {
   name?: string;
   countryId?: ResourceIdentifier;
   cityId?: ResourceIdentifier;
 }
 
-export type VenuesListParams = ControllerListParamsType<VenuesFilterInterface>;
+export type VenuesListParams = ControllerListParamsType<IVenuesFilter>;
 export type VenuesListResult = ControllerListResultType<VenuesViewModel>;
 export type VenueByIdResult = ControllerByIdResultType<VenueViewModel>;
 export type VenuesInjectDataResult = ControllerInjectionResultType;

--- a/apis/core-api/src/core/data/migrations/00000000000000-create-schemas.ts
+++ b/apis/core-api/src/core/data/migrations/00000000000000-create-schemas.ts
@@ -1,14 +1,14 @@
 import { ULTRAS_CORE, ULTRAS_LOGS } from '../lcp/schemas';
-import { QueryInterface } from 'sequelize';
+import { IQuery } from 'sequelize';
 
 export default {
-  async up(queryInterface: QueryInterface): Promise<void> {
-    await queryInterface.createSchema(ULTRAS_CORE);
-    await queryInterface.createSchema(ULTRAS_LOGS);
+  async up(Iquery: IQuery): Promise<void> {
+    await Iquery.createSchema(ULTRAS_CORE);
+    await Iquery.createSchema(ULTRAS_LOGS);
   },
 
-  async down(queryInterface: QueryInterface): Promise<void> {
-    /* await queryInterface.dropSchema(ULTRAS_CORE);
-    await queryInterface.dropSchema(ULTRAS_LOGS);*/
+  async down(Iquery: IQuery): Promise<void> {
+    /* await Iquery.dropSchema(ULTRAS_CORE);
+    await Iquery.dropSchema(ULTRAS_LOGS);*/
   },
 };

--- a/apis/core-api/src/core/data/migrations/00000000000001-create-likes.ts
+++ b/apis/core-api/src/core/data/migrations/00000000000001-create-likes.ts
@@ -1,5 +1,5 @@
 import { LikeTypeEnum } from '@ultras/utils';
-import { QueryInterface, DataTypes } from 'sequelize';
+import { IQuery, DataTypes } from 'sequelize';
 
 import resources from '../lcp/resources';
 import schemas, { ULTRAS_CORE } from '../lcp/schemas';
@@ -11,8 +11,8 @@ const table = {
 };
 
 export default {
-  async up(queryInterface: QueryInterface): Promise<void> {
-    await queryInterface.createTable(
+  async up(Iquery: IQuery): Promise<void> {
+    await Iquery.createTable(
       table,
       {
         id: {
@@ -90,11 +90,11 @@ export default {
       }
     );
 
-    await queryInterface.addIndex(table, ['userId', 'matchId'], { unique: true });
-    await queryInterface.addIndex(table, ['userId', 'postId'], { unique: true });
+    await Iquery.addIndex(table, ['userId', 'matchId'], { unique: true });
+    await Iquery.addIndex(table, ['userId', 'postId'], { unique: true });
   },
 
-  async down(queryInterface: QueryInterface): Promise<void> {
-    await queryInterface.dropTable(table);
+  async down(Iquery: IQuery): Promise<void> {
+    await Iquery.dropTable(table);
   },
 };

--- a/apis/core-api/src/core/data/seeders/20220301194201-fan-club-role-seeder.ts
+++ b/apis/core-api/src/core/data/seeders/20220301194201-fan-club-role-seeder.ts
@@ -1,4 +1,4 @@
-import { Sequelize, QueryInterface } from 'sequelize';
+import { Sequelize, IQuery } from 'sequelize';
 import { FanClubMemberRoleEnum } from '@ultras/utils';
 import { ULTRAS_CORE } from '../lcp/schemas';
 
@@ -8,8 +8,8 @@ const table = {
 };
 
 module.exports = {
-  async up(queryInterface: QueryInterface, sequelize: Sequelize) {
-    return queryInterface.bulkInsert(table, [
+  async up(Iquery: IQuery, sequelize: Sequelize) {
+    return Iquery.bulkInsert(table, [
       {
         role: FanClubMemberRoleEnum.owner,
         description: 'Fan club owner role.',
@@ -31,7 +31,7 @@ module.exports = {
     ]);
   },
 
-  async down(queryInterface: QueryInterface, sequelize: Sequelize) {
-    return queryInterface.bulkDelete('FanClubMemberRole', {}, {});
+  async down(Iquery: IQuery, sequelize: Sequelize) {
+    return Iquery.bulkDelete('FanClubMemberRole', {}, {});
   },
 };

--- a/apis/core-api/src/core/services/AuthService.ts
+++ b/apis/core-api/src/core/services/AuthService.ts
@@ -6,21 +6,21 @@ import jwt from 'jsonwebtoken';
 import db from 'core/data/models';
 import BaseService from './BaseService';
 
-interface DataToHashInterface {
+interface IDataToHash {
   userId: ResourceIdentifier;
   fingerprint: string;
 }
 
-interface FinalDataToHashInterface extends DataToHashInterface {
+interface IFinalDataToHash extends IDataToHash {
   expiresIn: number;
   expiresAt: number;
 }
 
-export interface AuthTokenResultInterface extends FinalDataToHashInterface {
+export interface IAuthTokenResult extends IFinalDataToHash {
   authToken: string;
 }
 
-export interface DeviceInformationInterface {
+export interface IDeviceInformation {
   ip: string;
   device: string;
   osName: string;
@@ -34,10 +34,10 @@ class AuthService extends BaseService {
    * Generate auth token based on user id and requested device.
    */
   static async generateAuthToken(
-    dataToHash: DataToHashInterface,
-    device: DeviceInformationInterface,
+    dataToHash: IDataToHash,
+    device: IDeviceInformation,
     transaction?: Transaction
-  ): ServiceResultType<AuthTokenResultInterface> {
+  ): ServiceResultType<IAuthTokenResult> {
     // force delete from database already expired sessions
     await db.UserSession.destroy({
       where: {
@@ -55,7 +55,7 @@ class AuthService extends BaseService {
     const expiresIn = authConfig.accessTokenLifetime;
     const expiresAt = Date.now() + expiresIn * 1000;
 
-    const finalDataToHash: FinalDataToHashInterface = {
+    const finalDataToHash: IFinalDataToHash = {
       ...dataToHash,
       expiresIn,
       expiresAt,
@@ -112,10 +112,7 @@ class AuthService extends BaseService {
    * Decode provided auth token.
    * In case of invalid auth token NULL will be returned.
    */
-  static decode<T = FinalDataToHashInterface>(
-    token: string,
-    ignoreExpiration = false
-  ): T | null {
+  static decode<T = IFinalDataToHash>(token: string, ignoreExpiration = false): T | null {
     try {
       const options = {
         ignoreExpiration: ignoreExpiration,

--- a/apis/core-api/src/core/services/CityService.ts
+++ b/apis/core-api/src/core/services/CityService.ts
@@ -14,7 +14,7 @@ import injectCities, { RapidApiCity } from 'core/data/inject-scripts/injectCitie
 import BaseService from './BaseService';
 import CountryService from './CountryService';
 
-export interface CitiesListParamsInterface {
+export interface ICitiesListParams {
   name?: string;
   countryId?: ResourceIdentifier;
 }
@@ -39,7 +39,7 @@ class CityService extends BaseService {
    * Get cities by provided filter data and pagination.
    */
   static async getAll(
-    params: ServiceListParamsType<CitiesListParamsInterface>
+    params: ServiceListParamsType<ICitiesListParams>
   ): ServiceListResultType<CityViewModel> {
     const query: any = this.queryInit();
 

--- a/apis/core-api/src/core/services/CommentService.ts
+++ b/apis/core-api/src/core/services/CommentService.ts
@@ -11,26 +11,26 @@ import resources from 'core/data/lcp';
 import db from 'core/data/models';
 import BaseService from './BaseService';
 
-interface CommentBasicParamsInterface {
+interface ICommentBasicParams {
   resourceType: CommentTypeEnum;
   resourceId: ResourceIdentifier;
 }
 
-interface CommentCreateParamsInterface extends CommentBasicParamsInterface {
+interface ICommentCreateParams extends ICommentBasicParams {
   userId: ResourceIdentifier;
   content: string;
 }
-interface CommentUpdateParamsInterface extends CommentBasicParamsInterface {
+interface ICommentUpdateParams extends ICommentBasicParams {
   userId: ResourceIdentifier;
   content: string;
   commentId: ResourceIdentifier;
 }
-interface CommentDeleteParamsInterface extends CommentBasicParamsInterface {
+interface ICommentDeleteParams extends ICommentBasicParams {
   userId: ResourceIdentifier;
   commentId: ResourceIdentifier;
 }
 
-interface FieldsByTypeInterface {
+interface IFieldsByType {
   fieldId: string;
   aliasName: string;
   model: any;
@@ -52,7 +52,7 @@ class CommentService extends BaseService {
     };
   }
 
-  private static getFieldsByType(resourceType: CommentTypeEnum): FieldsByTypeInterface {
+  private static getFieldsByType(resourceType: CommentTypeEnum): IFieldsByType {
     switch (resourceType) {
       case CommentTypeEnum.match:
         return {
@@ -73,7 +73,7 @@ class CommentService extends BaseService {
    * Get commenters by resource type, id and pagination.
    */
   static async getAll(
-    params: ServiceListParamsType<CommentBasicParamsInterface>
+    params: ServiceListParamsType<ICommentBasicParams>
   ): ServiceListResultType<CommentViewModel> {
     const { fieldId } = this.getFieldsByType(params.resourceType);
 
@@ -102,7 +102,7 @@ class CommentService extends BaseService {
   /**
    * Add comment under resource.
    */
-  static async comment(params: CommentCreateParamsInterface, transaction?: Transaction) {
+  static async comment(params: ICommentCreateParams, transaction?: Transaction) {
     const { fieldId } = this.getFieldsByType(params.resourceType);
 
     const comment = await db.Comment.create(
@@ -121,7 +121,7 @@ class CommentService extends BaseService {
   /**
    * Update comment under resource.
    */
-  static async update(params: CommentUpdateParamsInterface, transaction?: Transaction) {
+  static async update(params: ICommentUpdateParams, transaction?: Transaction) {
     const { fieldId } = this.getFieldsByType(params.resourceType);
 
     await db.Comment.update(
@@ -146,10 +146,7 @@ class CommentService extends BaseService {
   /**
    * Remove comment.
    */
-  static async uncomment(
-    params: CommentDeleteParamsInterface,
-    transaction?: Transaction
-  ) {
+  static async uncomment(params: ICommentDeleteParams, transaction?: Transaction) {
     const { fieldId } = this.getFieldsByType(params.resourceType);
 
     await db.Comment.destroy(

--- a/apis/core-api/src/core/services/CountryService.ts
+++ b/apis/core-api/src/core/services/CountryService.ts
@@ -16,7 +16,7 @@ import injectCountries, {
 import BaseService from './BaseService';
 import S3Service from './aws/S3Service';
 
-export interface CountriesListParamsInterface {
+export interface ICountriesListParams {
   name?: string;
   code?: string;
 }
@@ -26,7 +26,7 @@ class CountryService extends BaseService {
    * Get countries by provided filter data and pagination.
    */
   static async getAll(
-    params: ServiceListParamsType<CountriesListParamsInterface>
+    params: ServiceListParamsType<ICountriesListParams>
   ): ServiceListResultType<CountryViewModel> {
     const query: any = this.queryInit();
 

--- a/apis/core-api/src/core/services/EventService.ts
+++ b/apis/core-api/src/core/services/EventService.ts
@@ -19,12 +19,12 @@ import LocationService from './LocationService';
 import PostService from './PostService';
 import FanClubMemberService from './FanClubMemberService';
 
-export interface EventByIdParamsInterface {
+export interface IEventByIdParams {
   id: ResourceIdentifier;
   userId?: null | ResourceIdentifier;
 }
 
-export interface EventListParamsInterface {
+export interface IEventListParams {
   userId: ResourceIdentifier;
   search?: string;
   fanClubId?: ResourceIdentifier;
@@ -33,20 +33,20 @@ export interface EventListParamsInterface {
   teamId?: ResourceIdentifier;
 }
 
-export interface ActionByIdentifierInterface {
+export interface IActionByIdentifier {
   userId?: ResourceIdentifier;
   eventId?: ResourceIdentifier;
   teamId?: ResourceIdentifier;
 }
 
-export interface CreateParamsInterface {
+export interface ICreateParams {
   privacy: EventPrivacyEnum;
   dateTime: Date;
   locationId: ResourceIdentifier;
   postId: ResourceIdentifier;
 }
 
-export interface UpdateParamsInterface {
+export interface IUpdateParams {
   privacy: EventPrivacyEnum;
   dateTime: Date;
   locationId: ResourceIdentifier;
@@ -77,7 +77,7 @@ class EventService extends BaseService {
    * Create event instance.
    */
   static async create(
-    { dateTime, privacy, postId, locationId }: CreateParamsInterface,
+    { dateTime, privacy, postId, locationId }: ICreateParams,
     transaction?: Transaction
   ): Promise<EventViewModel> {
     const eventData: EventCreationAttributes = {
@@ -97,7 +97,7 @@ class EventService extends BaseService {
    */
   static async update(
     eventId: ResourceIdentifier,
-    { dateTime, privacy, locationId }: UpdateParamsInterface,
+    { dateTime, privacy, locationId }: IUpdateParams,
     transaction?: Transaction
   ): Promise<EventViewModel> {
     const event = await db.Event.findOne({
@@ -122,7 +122,7 @@ class EventService extends BaseService {
    * Get all events.
    */
   static async getAll(
-    params: ServiceListParamsType<EventListParamsInterface>
+    params: ServiceListParamsType<IEventListParams>
   ): ServiceListResultType<EventsViewModel> {
     // build generic query options
     const queryOptions: any = {
@@ -294,7 +294,7 @@ class EventService extends BaseService {
   /**
    * Get event by id.
    */
-  static async getById(params: EventByIdParamsInterface, withIncludes = true) {
+  static async getById(params: IEventByIdParams, withIncludes = true) {
     const event = await db.Event.findOne({
       where: {
         id: params.id,

--- a/apis/core-api/src/core/services/FanClubMemberService.ts
+++ b/apis/core-api/src/core/services/FanClubMemberService.ts
@@ -20,31 +20,28 @@ import {
 import BaseService from './BaseService';
 import FanClubService from './FanClubService';
 
-interface MembershipInterface {
+interface IMembership {
   fanClubId: ResourceIdentifier;
   memberId: ResourceIdentifier;
 }
-interface WithRoleInterface {
+interface IWithRole {
   role: FanClubMemberRoleEnum;
 }
-interface WithStatusInterface {
+interface IWithStatus {
   status: FanClubMemberStatusEnum;
 }
 
-interface CreateMemberInterface
-  extends Omit<MembershipInterface, 'memberId'>,
-    WithRoleInterface,
-    WithStatusInterface {
+interface ICreateMember extends Omit<IMembership, 'memberId'>, IWithRole, IWithStatus {
   inviterId?: ResourceIdentifier;
   memberId?: ResourceIdentifier;
 }
 
-interface RemoveMemberInterface extends Omit<MembershipInterface, 'memberId'> {
+interface IRemoveMember extends Omit<IMembership, 'memberId'> {
   memberId?: ResourceIdentifier;
   membershipId?: ResourceIdentifier;
 }
 
-export interface FanClubListParamsInterface {
+export interface IFanClubListParams {
   name?: string;
   countryId?: ResourceIdentifier;
   cityId?: ResourceIdentifier;
@@ -52,7 +49,7 @@ export interface FanClubListParamsInterface {
   ownerId?: ResourceIdentifier;
 }
 
-export interface FanClubMembershipListParamsInterface {
+export interface IFanClubMembershipListParams {
   search?: string;
   roleId?: ResourceIdentifier;
   status?: FanClubMemberStatusEnum;
@@ -60,7 +57,7 @@ export interface FanClubMembershipListParamsInterface {
   memberId?: ResourceIdentifier;
 }
 
-interface UpdateRoleStatusInterface {
+interface IUpdateRoleStatus {
   fanClubId: ResourceIdentifier;
   membershipId?: ResourceIdentifier;
   memberId?: ResourceIdentifier;
@@ -96,7 +93,7 @@ class FanClubMemberService extends BaseService {
    * Add member to fan club.
    */
   static async add(
-    { fanClubId, memberId, role, status }: CreateMemberInterface,
+    { fanClubId, memberId, role, status }: ICreateMember,
     transaction?: Transaction
   ): Promise<null | FanClubMemberViewModel> {
     const fanClub = await db.FanClub.findByPk(fanClubId, { transaction });
@@ -179,7 +176,7 @@ class FanClubMemberService extends BaseService {
   /**
    * Remove member from fan club.
    */
-  static async remove({ fanClubId, membershipId, memberId }: RemoveMemberInterface) {
+  static async remove({ fanClubId, membershipId, memberId }: IRemoveMember) {
     const conditions: any = {
       fanClubId: fanClubId,
     };
@@ -302,7 +299,7 @@ class FanClubMemberService extends BaseService {
     memberId,
     role,
     status,
-  }: UpdateRoleStatusInterface) {
+  }: IUpdateRoleStatus) {
     const updateField: any = {};
     if (role) {
       const roleId = await this.getRoleId(role);
@@ -391,7 +388,7 @@ class FanClubMemberService extends BaseService {
    * Get fan club memberships by provided filters.
    */
   static async getAll(
-    params: ServiceListParamsType<FanClubMembershipListParamsInterface>
+    params: ServiceListParamsType<IFanClubMembershipListParams>
   ): ServiceListResultType<FanClubMemberViewModel> {
     // fan club id or memberId must be provided
     if (!params.fanClubId && !params.memberId) {

--- a/apis/core-api/src/core/services/FanClubService.ts
+++ b/apis/core-api/src/core/services/FanClubService.ts
@@ -16,7 +16,7 @@ import CityService from './CityService';
 import CountryService from './CountryService';
 import TeamService from './TeamService';
 
-export interface FanClubListParamsInterface {
+export interface IFanClubListParams {
   userId?: ResourceIdentifier | null;
   name?: string;
   countryId?: ResourceIdentifier;
@@ -25,7 +25,7 @@ export interface FanClubListParamsInterface {
   ownerId?: ResourceIdentifier;
 }
 
-export interface FanClubMembershipListParamsInterface {
+export interface IFanClubMembershipListParams {
   name: string;
   fanClubId: ResourceIdentifier;
 }
@@ -155,7 +155,7 @@ class FanClubService extends BaseService {
    * Get fan clubs by provided filter data and pagination.
    */
   static async getAll(
-    params: ServiceListParamsType<FanClubListParamsInterface>
+    params: ServiceListParamsType<IFanClubListParams>
   ): ServiceListResultType<FanClubAttributes> {
     const query: any = this.queryInit();
 

--- a/apis/core-api/src/core/services/FavoriteTeamService.ts
+++ b/apis/core-api/src/core/services/FavoriteTeamService.ts
@@ -27,24 +27,24 @@ import {
   InsufficientResource,
 } from 'modules/exceptions';
 
-export interface FavoriteTeamByUserListParamsInterface {
+export interface IFavoriteTeamByUserListParams {
   userId?: ResourceIdentifier;
   search?: string;
 }
 
-export interface FavoriteTeamListParamsInterface {
+export interface IFavoriteTeamListParams {
   userId?: ResourceIdentifier;
   teamId?: ResourceIdentifier;
   search?: string;
 }
 
-export interface ActionByIdentifierInterface {
+export interface IActionByIdentifier {
   userId?: ResourceIdentifier;
   favoriteTeamId?: ResourceIdentifier;
   teamId?: ResourceIdentifier;
 }
 
-export interface AddSingleParamsInterface {
+export interface IAddSingleParams {
   userId: ResourceIdentifier;
   teamId: ResourceIdentifier | Array<ResourceIdentifier>;
 }
@@ -72,7 +72,7 @@ class FavoriteTeamService extends BaseService {
   /**
    * Build query condition.
    */
-  private static buildActionCondition(params: ActionByIdentifierInterface) {
+  private static buildActionCondition(params: IActionByIdentifier) {
     // if no any unique identifier provided then null returned
     // there is no way to determine favorite team.
     if (Object.keys(params).length == 0) {
@@ -106,7 +106,7 @@ class FavoriteTeamService extends BaseService {
    * Add user new favorite team.
    */
   static async add(
-    { userId, teamId }: AddSingleParamsInterface,
+    { userId, teamId }: IAddSingleParams,
     transaction?: Transaction
   ): Promise<FavoriteTeamsViewModel> {
     if (!Array.isArray(teamId)) {
@@ -134,7 +134,7 @@ class FavoriteTeamService extends BaseService {
    * Get all favorite teams by user id.
    */
   static async getAllTeams(
-    params: ServiceListParamsType<FavoriteTeamByUserListParamsInterface>
+    params: ServiceListParamsType<IFavoriteTeamByUserListParams>
   ): ServiceListResultType<TeamsViewModel> {
     // generate subquery
     const subquerySel = db.sequelize.dialect.queryGenerator
@@ -188,7 +188,7 @@ class FavoriteTeamService extends BaseService {
    * Get all favorite teams by user id.
    */
   static async getAll(
-    params: ServiceListParamsType<FavoriteTeamListParamsInterface>
+    params: ServiceListParamsType<IFavoriteTeamListParams>
   ): ServiceListResultType<FavoriteTeamsViewModel> {
     // teamId or userId must be provided
     if (!params.userId && !params.teamId) {
@@ -276,7 +276,7 @@ class FavoriteTeamService extends BaseService {
    * Get favorite team by pivot table id.
    */
   static async getByIdentifier(
-    params: ActionByIdentifierInterface
+    params: IActionByIdentifier
   ): ServiceByIdResultType<FavoriteTeamViewModel> {
     const condition = this.buildActionCondition(params);
     if (!condition) {
@@ -295,12 +295,12 @@ class FavoriteTeamService extends BaseService {
    * Remove user new favorite team.
    */
   static async remove(
-    params: ActionByIdentifierInterface,
+    params: IActionByIdentifier,
     transaction?: Transaction
   ): Promise<void> {
     // if favoriteTeamId provided then other field must be ignored
     // if no any field provided then nothing to do
-    const identifier: ActionByIdentifierInterface = {};
+    const identifier: IActionByIdentifier = {};
     if (params.favoriteTeamId) {
       identifier.favoriteTeamId = params.favoriteTeamId;
     } else if (params.userId && params.teamId) {

--- a/apis/core-api/src/core/services/LeagueService.ts
+++ b/apis/core-api/src/core/services/LeagueService.ts
@@ -15,7 +15,7 @@ import injectLeagues, { RapidApiLeague } from 'core/data/inject-scripts/injectLe
 import BaseService from './BaseService';
 import CountryService from './CountryService';
 
-export interface LeaguesListParamsInterface {
+export interface ILeaguesListParams {
   name?: string;
   countryId?: ResourceIdentifier;
 }
@@ -40,7 +40,7 @@ class LeagueService extends BaseService {
    * Get leagues by provided filter data and pagination.
    */
   static async getAll(
-    params: ServiceListParamsType<LeaguesListParamsInterface>
+    params: ServiceListParamsType<ILeaguesListParams>
   ): ServiceListResultType<LeagueViewModel> {
     const query: any = this.queryInit();
 

--- a/apis/core-api/src/core/services/LikeService.ts
+++ b/apis/core-api/src/core/services/LikeService.ts
@@ -7,23 +7,23 @@ import resources from 'core/data/lcp';
 import db from 'core/data/models';
 import BaseService from './BaseService';
 
-interface LikeBasicParamsInterface {
+interface ILikeBasicParams {
   resourceType: LikeTypeEnum;
   resourceId: ResourceIdentifier;
 }
 
-interface LikeUnlikeParamsInterface extends LikeBasicParamsInterface {
+interface ILikeUnlikeParams extends ILikeBasicParams {
   userId: ResourceIdentifier;
 }
 
-interface FieldsByTypeInterface {
+interface IFieldsByType {
   fieldId: string;
   throughAlias: string;
   model: any;
 }
 
 class LikeService extends BaseService {
-  private static getFieldsByType(resourceType: LikeTypeEnum): FieldsByTypeInterface {
+  private static getFieldsByType(resourceType: LikeTypeEnum): IFieldsByType {
     switch (resourceType) {
       case LikeTypeEnum.match:
         return {
@@ -44,7 +44,7 @@ class LikeService extends BaseService {
    * Get likes by resource type, id and pagination.
    */
   static async getAll(
-    params: ServiceListParamsType<LikeBasicParamsInterface>
+    params: ServiceListParamsType<ILikeBasicParams>
   ): ServiceListResultType<UserViewModel> {
     const { fieldId, throughAlias, model } = this.getFieldsByType(params.resourceType);
 
@@ -74,7 +74,7 @@ class LikeService extends BaseService {
   /**
    * Make resource liked by user.
    */
-  static async like(params: LikeUnlikeParamsInterface, transaction?: Transaction) {
+  static async like(params: ILikeUnlikeParams, transaction?: Transaction) {
     const { fieldId } = this.getFieldsByType(params.resourceType);
 
     await db.Like.create(
@@ -90,7 +90,7 @@ class LikeService extends BaseService {
   /**
    * Make resource un-liked by user.
    */
-  static async unlike(params: LikeUnlikeParamsInterface, transaction?: Transaction) {
+  static async unlike(params: ILikeUnlikeParams, transaction?: Transaction) {
     const { fieldId } = this.getFieldsByType(params.resourceType);
 
     await db.Like.destroy(

--- a/apis/core-api/src/core/services/LocationService.ts
+++ b/apis/core-api/src/core/services/LocationService.ts
@@ -8,17 +8,17 @@ import { LocationCreationAttributes } from 'core/data/models/Location';
 
 import BaseService from './BaseService';
 
-export interface LocationListParamsInterface {
+export interface ILocationListParams {
   search?: string;
 }
 
-export interface CreateParamsInterface {
+export interface ICreateParams {
   name: string;
   lat?: Nullable<number>;
   lng?: Nullable<number>;
 }
 
-export interface SearchParamsInterface {
+export interface ISearchParams {
   name?: Nullable<string>;
   lat?: Nullable<number>;
   lng?: Nullable<number>;
@@ -29,7 +29,7 @@ class LocationService extends BaseService {
    * Create location instance.
    */
   static async create(
-    { name, lat, lng }: CreateParamsInterface,
+    { name, lat, lng }: ICreateParams,
     transaction?: Transaction
   ): ServiceResultType<LocationViewModel> {
     const locationData: LocationCreationAttributes = {
@@ -46,7 +46,7 @@ class LocationService extends BaseService {
   /**
    * Search location.
    */
-  static async get({ name, lat, lng }: SearchParamsInterface) {
+  static async get({ name, lat, lng }: ISearchParams) {
     const filterParams: any = {};
 
     if (name) {
@@ -76,10 +76,7 @@ class LocationService extends BaseService {
   /**
    * Create or get location instance.
    */
-  static async createOrGet(
-    { name, lat, lng }: CreateParamsInterface,
-    transaction?: Transaction
-  ) {
+  static async createOrGet({ name, lat, lng }: ICreateParams, transaction?: Transaction) {
     if (!name && (!lat || !lng)) {
       return null;
     }

--- a/apis/core-api/src/core/services/MatchService.ts
+++ b/apis/core-api/src/core/services/MatchService.ts
@@ -16,7 +16,7 @@ import TeamService from './TeamService';
 import VenueService from './VenueService';
 import LeagueService from './LeagueService';
 
-export interface MatchesListParamsInterface {
+export interface IMatchesListParams {
   search?: string;
   dateFrom?: string;
   dateTo?: string;
@@ -71,7 +71,7 @@ class MatchService extends BaseService {
    * Get matches by provided filter data and pagination.
    */
   static async getAll(
-    params: ServiceListParamsType<MatchesListParamsInterface>
+    params: ServiceListParamsType<IMatchesListParams>
   ): ServiceListResultType<MatchViewModel> {
     const query: any = this.queryInit();
 

--- a/apis/core-api/src/core/services/PostMemberService.ts
+++ b/apis/core-api/src/core/services/PostMemberService.ts
@@ -11,22 +11,22 @@ import UserService from './UserService';
 
 import BaseService from './BaseService';
 
-export interface CreateParamsInterface {
+export interface ICreateParams {
   userId: ResourceIdentifier;
   postId: ResourceIdentifier;
 }
 
-export interface FindParamsInterface {
+export interface IFindParams {
   userId: ResourceIdentifier;
   postId: ResourceIdentifier;
 }
 
-export interface FindAllParamsInterface {
+export interface IFindAllParams {
   postId: ResourceIdentifier;
   search?: string;
 }
 
-export interface DeleteParamsInterface {
+export interface IDeleteParams {
   userId: ResourceIdentifier;
   postId: ResourceIdentifier;
 }
@@ -55,10 +55,7 @@ class PostMemberService extends BaseService {
   /**
    * Create post member instance.
    */
-  static async create(
-    { postId, userId }: CreateParamsInterface,
-    transaction?: Transaction
-  ) {
+  static async create({ postId, userId }: ICreateParams, transaction?: Transaction) {
     const postData: PostMemberCreationAttributes = {
       userId,
       postId,
@@ -71,7 +68,7 @@ class PostMemberService extends BaseService {
   /**
    * Delete post member.
    */
-  static delete({ postId, userId }: DeleteParamsInterface, transaction?: Transaction) {
+  static delete({ postId, userId }: IDeleteParams, transaction?: Transaction) {
     return db.PostMember.destroy(
       {
         force: true,
@@ -87,7 +84,7 @@ class PostMemberService extends BaseService {
   /**
    * Get post member.
    */
-  static getOne({ postId, userId }: FindParamsInterface) {
+  static getOne({ postId, userId }: IFindParams) {
     return db.PostMember.findOne({
       where: {
         postId,
@@ -99,7 +96,7 @@ class PostMemberService extends BaseService {
   /**
    * Get all post member.
    */
-  static async getAll(params: ServiceListParamsType<FindAllParamsInterface>) {
+  static async getAll(params: ServiceListParamsType<IFindAllParams>) {
     // build generic query options
     const queryOptions: any = {
       limit: params.limit,

--- a/apis/core-api/src/core/services/PostService.ts
+++ b/apis/core-api/src/core/services/PostService.ts
@@ -9,7 +9,7 @@ import BaseService from './BaseService';
 import FanClubService from './FanClubService';
 import MatchService from './MatchService';
 
-export interface CreateParamsInterface {
+export interface ICreateParams {
   image?: Nullable<string>;
   authorId: ResourceIdentifier;
   title: string;
@@ -19,7 +19,7 @@ export interface CreateParamsInterface {
   type: PostTypeEnum;
 }
 
-export interface UpdateParamsInterface {
+export interface IUpdateParams {
   image?: Nullable<string>;
   title: string;
   content: string;
@@ -78,7 +78,7 @@ class PostService extends BaseService {
    * Create post instance.
    */
   static async create(
-    { image, authorId, title, content, fanClubId, matchId, type }: CreateParamsInterface,
+    { image, authorId, title, content, fanClubId, matchId, type }: ICreateParams,
     transaction?: Transaction
   ) {
     const postData: PostCreationAttributes = {
@@ -102,7 +102,7 @@ class PostService extends BaseService {
    */
   static async update(
     postId: ResourceIdentifier,
-    { image, title, content }: UpdateParamsInterface,
+    { image, title, content }: IUpdateParams,
     transaction?: Transaction
   ) {
     const post = await db.Post.findOne({

--- a/apis/core-api/src/core/services/RoomService.ts
+++ b/apis/core-api/src/core/services/RoomService.ts
@@ -16,25 +16,25 @@ import BaseService from './BaseService';
 import PostService from './PostService';
 import FanClubMemberService from './FanClubMemberService';
 
-export interface RoomByIdParamsInterface {
+export interface IRoomByIdParams {
   id: ResourceIdentifier;
   userId?: null | ResourceIdentifier;
 }
 
-export interface RoomListParamsInterface {
+export interface IRoomListParams {
   userId: null | ResourceIdentifier;
   search?: string;
   fanClubId?: ResourceIdentifier | Array<ResourceIdentifier>;
   authorId?: ResourceIdentifier;
 }
 
-export interface CreateParamsInterface {
+export interface ICreateParams {
   dateTime: Date;
   privacy: RoomPrivacyEnum;
   postId: ResourceIdentifier;
 }
 
-export interface UpdateParamsInterface {
+export interface IUpdateParams {
   dateTime: Date;
   privacy: RoomPrivacyEnum;
 }
@@ -59,7 +59,7 @@ class RoomService extends BaseService {
    * Create room instance.
    */
   static async create(
-    { dateTime, privacy, postId }: CreateParamsInterface,
+    { dateTime, privacy, postId }: ICreateParams,
     transaction?: Transaction
   ): Promise<RoomViewModel> {
     const roomData: RoomCreationAttributes = {
@@ -77,7 +77,7 @@ class RoomService extends BaseService {
    * Get all rooms.
    */
   static async getAll(
-    params: ServiceListParamsType<RoomListParamsInterface>
+    params: ServiceListParamsType<IRoomListParams>
   ): ServiceListResultType<RoomsViewModel> {
     let userFanClubIdsMember: null | Array<ResourceIdentifier> = null;
     let userFanClubIdsAdmin: null | Array<ResourceIdentifier> = null;
@@ -245,7 +245,7 @@ class RoomService extends BaseService {
   /**
    * Get room by id.
    */
-  static async getById(params: RoomByIdParamsInterface, withIncludes = true) {
+  static async getById(params: IRoomByIdParams, withIncludes = true) {
     const room = await db.Room.findOne({
       where: {
         id: params.id,
@@ -261,7 +261,7 @@ class RoomService extends BaseService {
    */
   static async update(
     roomId: ResourceIdentifier,
-    { privacy, dateTime }: UpdateParamsInterface,
+    { privacy, dateTime }: IUpdateParams,
     transaction?: Transaction
   ): Promise<RoomViewModel> {
     const room = await db.Room.findOne({

--- a/apis/core-api/src/core/services/TeamService.ts
+++ b/apis/core-api/src/core/services/TeamService.ts
@@ -17,7 +17,7 @@ import CountryService from './CountryService';
 import CityService from './CityService';
 import VenueService from './VenueService';
 
-export interface TeamsListParamsInterface {
+export interface ITeamsListParams {
   name?: string;
   countryId?: ResourceIdentifier;
   cityId?: ResourceIdentifier;
@@ -55,7 +55,7 @@ class TeamService extends BaseService {
    * Get teams by provided filter data and pagination.
    */
   static async getAll(
-    params: ServiceListParamsType<TeamsListParamsInterface>
+    params: ServiceListParamsType<ITeamsListParams>
   ): ServiceListResultType<TeamViewModel> {
     const query: any = this.queryInit();
 

--- a/apis/core-api/src/core/services/UserService.ts
+++ b/apis/core-api/src/core/services/UserService.ts
@@ -6,7 +6,7 @@ import { User, UserCreationAttributes } from 'core/data/models/User';
 
 import BaseService from './BaseService';
 
-interface UserUniqueIdentifierInterface {
+interface IUserUniqueIdentifier {
   phone?: null | string;
   email?: null | string;
   username?: null | string;
@@ -104,7 +104,7 @@ class UserService extends BaseService {
    * 4) email
    */
   static async findByUniqueIdentifier(
-    identifier: UserUniqueIdentifierInterface
+    identifier: IUserUniqueIdentifier
   ): ServiceResultType<null | User> {
     const query = this.queryInit();
 

--- a/apis/core-api/src/core/services/VenueService.ts
+++ b/apis/core-api/src/core/services/VenueService.ts
@@ -16,7 +16,7 @@ import BaseService from './BaseService';
 import CountryService from './CountryService';
 import CityService from './CityService';
 
-export interface VenuesListParamsInterface {
+export interface IVenuesListParams {
   name?: string;
   countryId?: ResourceIdentifier;
   cityId?: ResourceIdentifier;
@@ -47,7 +47,7 @@ class VenueService extends BaseService {
    * Get venues by provided filter data and pagination.
    */
   static async getAll(
-    params: ServiceListParamsType<VenuesListParamsInterface>
+    params: ServiceListParamsType<IVenuesListParams>
   ): ServiceListResultType<VenueViewModel> {
     const query: any = this.queryInit();
 

--- a/apis/core-api/src/core/services/VerificationCodeService.ts
+++ b/apis/core-api/src/core/services/VerificationCodeService.ts
@@ -7,20 +7,20 @@ import { VerificationCodeAttributes } from 'core/data/models/VerificationCode';
 
 import BaseService from './BaseService';
 
-interface StoreInterface {
+interface IStore {
   code: string;
   provider: NotifiedProviderEnum;
   phone?: null | string;
   email?: null | string;
 }
 
-interface ValidateParamsInterface {
+interface IValidateParams {
   code: string;
   phone?: null | string;
   email?: null | string;
 }
 
-interface ValidateResultInterface {
+interface IValidateResult {
   isValid: boolean;
   provider: null | NotifiedProviderEnum;
 }
@@ -39,7 +39,7 @@ class VerificationCodeService extends BaseService {
    * If user specific field not provided then NULL will be returned.
    */
   private static buildQuery(
-    { code, phone, email }: ValidateParamsInterface,
+    { code, phone, email }: IValidateParams,
     checkExpirations: boolean
   ) {
     const query: any = {
@@ -84,7 +84,7 @@ class VerificationCodeService extends BaseService {
    * Store generated verification code with user specific identifier.
    */
   static async store(
-    { code, provider, phone, email }: StoreInterface,
+    { code, provider, phone, email }: IStore,
     transaction?: Transaction
   ): Promise<void> {
     const expirationTimestamp = Date.now() + expireAfterMs;
@@ -124,7 +124,7 @@ class VerificationCodeService extends BaseService {
     code,
     phone,
     email,
-  }: ValidateParamsInterface): Promise<VerificationCodeAttributes | null> {
+  }: IValidateParams): Promise<VerificationCodeAttributes | null> {
     const query: any = this.buildQuery({ code, phone, email }, true);
     if (!query) {
       return null;
@@ -141,7 +141,7 @@ class VerificationCodeService extends BaseService {
    * Remove verification code by code and user specific identifier.
    */
   static async removeVerificationCode(
-    { code, phone, email }: ValidateParamsInterface,
+    { code, phone, email }: IValidateParams,
     transaction?: Transaction
   ): Promise<void> {
     const query: any = this.buildQuery({ code, phone, email }, false);

--- a/clients/app/src/stores/cities.ts
+++ b/clients/app/src/stores/cities.ts
@@ -8,10 +8,10 @@ import {
   Filterable,
   FullFilterable,
   generateCRUD,
-  InitStoreParamsInterface,
+  IInitStoreParams,
 } from './generateCRUD';
 
-type ParamType<TScheme> = InitStoreParamsInterface<CityViewModel, TScheme>;
+type ParamType<TScheme> = IInitStoreParams<CityViewModel, TScheme>;
 type FilterType = Filterable<GetCitiesFilter>;
 
 const sdk = new CitySDK('dev');

--- a/clients/app/src/stores/countries.ts
+++ b/clients/app/src/stores/countries.ts
@@ -8,11 +8,11 @@ import {
   Filterable,
   FullFilterable,
   generateCRUD,
-  InitStoreParamsInterface,
+  IInitStoreParams,
 } from './generateCRUD';
 import { OrderEnum } from '@ultras/utils';
 
-type ParamType<TScheme> = InitStoreParamsInterface<CountryViewModel, TScheme>;
+type ParamType<TScheme> = IInitStoreParams<CountryViewModel, TScheme>;
 type FilterType = Filterable<GetCountriesFilter>;
 
 const sdk = new CountrySDK('dev');

--- a/clients/app/src/stores/eventMembers/types.ts
+++ b/clients/app/src/stores/eventMembers/types.ts
@@ -2,10 +2,10 @@ import type { EventMemberViewModel, GetEventMembersFilter } from '@ultras/core-a
 import type {
   Filterable,
   FullFilterable,
-  InitStoreParamsInterface,
+  IInitStoreParams,
 } from '../generateCRUD';
 
-export type ParamType = InitStoreParamsInterface<EventMemberViewModel>;
+export type ParamType = IInitStoreParams<EventMemberViewModel>;
 export type FilterType = Filterable<GetEventMembersFilter>;
 
 export type TCreateEventMember = {

--- a/clients/app/src/stores/events/events.ts
+++ b/clients/app/src/stores/events/events.ts
@@ -10,12 +10,12 @@ import {
   Filterable,
   FullFilterable,
   generateCRUD,
-  InitStoreParamsInterface,
+  IInitStoreParams,
 } from '../generateCRUD';
 
 import { scheme } from './scheme';
 
-type ParamType<TScheme> = InitStoreParamsInterface<EventViewModel, TScheme>;
+type ParamType<TScheme> = IInitStoreParams<EventViewModel, TScheme>;
 type FilterType = Filterable<GetEventsFilter>;
 
 type TDeleteEvent = {

--- a/clients/app/src/stores/events/scheme.ts
+++ b/clients/app/src/stores/events/scheme.ts
@@ -1,7 +1,7 @@
 import { EventPrivacyEnum } from '@ultras/utils';
-import { SchemeInterface } from '../generateCRUD/types/scheme';
+import { IScheme } from '../generateCRUD/types/scheme';
 
-interface DataTypeInterface {
+interface IDataType {
   matchId: null | ResourceIdentifier;
   title: string;
   privacy: EventPrivacyEnum;
@@ -12,7 +12,7 @@ interface DataTypeInterface {
   content: null | string;
 }
 
-export const scheme: SchemeInterface<DataTypeInterface> = {
+export const scheme: IScheme<IDataType> = {
   matchId: {
     initialValue: null,
     validate(valueOriginal: null | ResourceIdentifier) {

--- a/clients/app/src/stores/fanClubMembers.ts
+++ b/clients/app/src/stores/fanClubMembers.ts
@@ -9,10 +9,10 @@ import {
   Filterable,
   FullFilterable,
   generateCRUD,
-  InitStoreParamsInterface,
+  IInitStoreParams,
 } from './generateCRUD';
 
-type ParamType<TScheme> = InitStoreParamsInterface<FanClubMemberViewModel, TScheme>;
+type ParamType<TScheme> = IInitStoreParams<FanClubMemberViewModel, TScheme>;
 type FilterType = Filterable<GetFanClubMembershipsFilter>;
 
 type TDeleteFanClubMember = {

--- a/clients/app/src/stores/fanClubs/fanClubs.ts
+++ b/clients/app/src/stores/fanClubs/fanClubs.ts
@@ -9,12 +9,12 @@ import {
   Filterable,
   FullFilterable,
   generateCRUD,
-  InitStoreParamsInterface,
+  IInitStoreParams,
 } from '../generateCRUD';
 
-import { DataTypeInterface, scheme } from './scheme';
+import { IDataType, scheme } from './scheme';
 
-type ParamType<TScheme> = InitStoreParamsInterface<FanClubViewModel, TScheme>;
+type ParamType<TScheme> = IInitStoreParams<FanClubViewModel, TScheme>;
 type FilterType = Filterable<GetFanClubsFilter>;
 
 type TDeleteEvent = {
@@ -23,7 +23,7 @@ type TDeleteEvent = {
 
 const sdk = new FanClubSDK('dev');
 
-const buildFanClubsStore = <TScheme = DataTypeInterface>(
+const buildFanClubsStore = <TScheme = IDataType>(
   params: Partial<ParamType<TScheme>> = {}
 ) => {
   // return generateCRUD<FanClubViewModel, FilterType, 'list' | 'single' | 'add'>({

--- a/clients/app/src/stores/fanClubs/scheme.ts
+++ b/clients/app/src/stores/fanClubs/scheme.ts
@@ -1,7 +1,7 @@
 import { FanClubPrivacyEnum } from '@ultras/utils';
-import { SchemeInterface } from '../generateCRUD/types/scheme';
+import { IScheme } from '../generateCRUD/types/scheme';
 
-export interface DataTypeInterface {
+export interface IDataType {
   name: string;
   teamId: null | ResourceIdentifier;
   cityId: null | ResourceIdentifier;
@@ -9,7 +9,7 @@ export interface DataTypeInterface {
   description: null | string;
 }
 
-export const scheme: SchemeInterface<DataTypeInterface> = {
+export const scheme: IScheme<IDataType> = {
   teamId: {
     initialValue: null,
     validate(valueOriginal: null | ResourceIdentifier) {

--- a/clients/app/src/stores/favoriteTeams.ts
+++ b/clients/app/src/stores/favoriteTeams.ts
@@ -9,10 +9,10 @@ import {
   Filterable,
   FullFilterable,
   generateCRUD,
-  InitStoreParamsInterface,
+  IInitStoreParams,
 } from './generateCRUD';
 
-type ParamType<TScheme> = InitStoreParamsInterface<TeamViewModel, TScheme>;
+type ParamType<TScheme> = IInitStoreParams<TeamViewModel, TScheme>;
 type FilterType = Filterable<GetFavoriteTeamsFilter>;
 
 type TCreateFavoriteTeam = {

--- a/clients/app/src/stores/generateCRUD/crud/add.ts
+++ b/clients/app/src/stores/generateCRUD/crud/add.ts
@@ -1,9 +1,9 @@
-import type { AddStateDataInterface } from '../types/crud/add';
+import type { IAddStateData } from '../types/crud/add';
 import type {
-  BeforeSendInterface,
-  SchemeInterface,
-  StateDataSchemeInterface,
-  StateFieldSchemeInterface,
+  IBeforeSend,
+  IScheme,
+  IStateDataScheme,
+  IStateFieldScheme,
 } from '../types/scheme';
 import type {
   RootStoreType,
@@ -19,10 +19,10 @@ import { createField } from '../utils/helpers';
 type CurrentStoreKeyType = 'add';
 
 function generateInitialState<TData, TScheme>(
-  scheme: SchemeInterface<TScheme> | null | undefined
-): AddStateDataInterface<TData, TScheme> {
+  scheme: IScheme<TScheme> | null | undefined
+): IAddStateData<TData, TScheme> {
   // @ts-ignore
-  const stateAddData: StateDataSchemeInterface<TScheme> = {};
+  const stateAddData: IStateDataScheme<TScheme> = {};
 
   if (scheme) {
     Object.keys(scheme).forEach((keyName: string) => {
@@ -53,7 +53,7 @@ export const buildInitialState = <TData, TFilter, TScheme>(
     TFilter,
     TScheme
   >,
-  scheme: SchemeInterface<TScheme> | null | undefined
+  scheme: IScheme<TScheme> | null | undefined
 ) => {
   state.add = generateInitialState<TData, TScheme>(scheme);
 };
@@ -179,17 +179,17 @@ export const buildActions = <TData, TFilter, TScheme>(
     }
 
     const state = Object.keys(mapData).reduce(
-      (acc: StateDataSchemeInterface<TScheme>, keyName: string) => {
+      (acc: IStateDataScheme<TScheme>, keyName: string) => {
         const key = keyName as keyof TScheme;
 
         acc[key] = addData[key];
         return acc;
       },
-      {} as StateDataSchemeInterface<TScheme>
+      {} as IStateDataScheme<TScheme>
     );
 
     const stateValues = Object.values(state) as Array<
-      StateFieldSchemeInterface<keyof TScheme>
+      IStateFieldScheme<keyof TScheme>
     >;
 
     for (const stateItem of stateValues) {
@@ -204,7 +204,7 @@ export const buildActions = <TData, TFilter, TScheme>(
     // received result must be sent to backend, otherwise state values will
     // be used to send to backend.
     if (typeof interceptors.beforeSend === 'function') {
-      const beforeSendCall = interceptors.beforeSend as BeforeSendInterface<
+      const beforeSendCall = interceptors.beforeSend as IBeforeSend<
         TData,
         TScheme
       >;

--- a/clients/app/src/stores/generateCRUD/crud/delete.ts
+++ b/clients/app/src/stores/generateCRUD/crud/delete.ts
@@ -1,4 +1,4 @@
-import type { DeleteStateDataInterface } from '../types/crud/delete';
+import type { IDeleteStateData } from '../types/crud/delete';
 import type {
   RootStoreType,
   ExtractStateType,
@@ -10,7 +10,7 @@ import type {
 
 type CurrentStoreKeyType = 'delete';
 
-function generateInitialState<TData>(): DeleteStateDataInterface<TData> {
+function generateInitialState<TData>(): IDeleteStateData<TData> {
   return {
     status: 'default',
     error: null,

--- a/clients/app/src/stores/generateCRUD/crud/list.ts
+++ b/clients/app/src/stores/generateCRUD/crud/list.ts
@@ -1,4 +1,4 @@
-import type { ListStateDataInterface } from '../types/crud/list';
+import type { IListStateData } from '../types/crud/list';
 import type { FullFilterable } from '../types/common';
 import type {
   RootStoreType,
@@ -13,7 +13,7 @@ import { buildFilterHash } from '../utils/helpers';
 
 type CurrentStoreKeyType = 'list';
 
-function generateInitialState<TData, TFilter>(): ListStateDataInterface<TData, TFilter> {
+function generateInitialState<TData, TFilter>(): IListStateData<TData, TFilter> {
   return {
     status: 'loading',
     error: null,
@@ -106,7 +106,7 @@ export const buildActions = <TData, TFilter, TScheme>(
 
   // add getAll method to action list, that just calling loadAll interceptor method
   // and updates "list" state
-  actions.getAll = async (): Promise<ListStateDataInterface<TData, TFilter>> => {
+  actions.getAll = async (): Promise<IListStateData<TData, TFilter>> => {
     const list = getState().list;
 
     // we need to reset previously loaded data if filter was changed

--- a/clients/app/src/stores/generateCRUD/crud/single.ts
+++ b/clients/app/src/stores/generateCRUD/crud/single.ts
@@ -1,4 +1,4 @@
-import type { SingleStateDataInterface } from '../types/crud/single';
+import type { ISingleStateData } from '../types/crud/single';
 import type {
   RootStoreType,
   ExtractStateType,
@@ -10,7 +10,7 @@ import type {
 
 type CurrentStoreKeyType = 'single';
 
-function generateInitialState<TData>(): SingleStateDataInterface<TData> {
+function generateInitialState<TData>(): ISingleStateData<TData> {
   return {
     status: 'loading',
     error: null,
@@ -81,7 +81,7 @@ export const buildActions = <TData, TFilter, TScheme>(
   // and updates "single" state
   actions.getSingle = async (
     id: ResourceIdentifier
-  ): Promise<SingleStateDataInterface<TData>> => {
+  ): Promise<ISingleStateData<TData>> => {
     const single = getState().single;
     single.status = 'loading';
     setState({ single });

--- a/clients/app/src/stores/generateCRUD/crud/update.ts
+++ b/clients/app/src/stores/generateCRUD/crud/update.ts
@@ -1,9 +1,9 @@
-import type { UpdateStateDataInterface } from '../types/crud/update';
+import type { IUpdateStateData } from '../types/crud/update';
 import type {
-  BeforeSendInterface,
-  SchemeInterface,
-  StateDataSchemeInterface,
-  StateFieldSchemeInterface,
+  IBeforeSend,
+  IScheme,
+  IStateDataScheme,
+  IStateFieldScheme,
 } from '../types/scheme';
 import type {
   RootStoreType,
@@ -19,10 +19,10 @@ import { createField } from '../utils/helpers';
 type CurrentStoreKeyType = 'update';
 
 function generateInitialState<TData, TScheme>(
-  scheme: SchemeInterface<TScheme> | null | undefined
-): UpdateStateDataInterface<TData, TScheme> {
+  scheme: IScheme<TScheme> | null | undefined
+): IUpdateStateData<TData, TScheme> {
   // @ts-ignore
-  const stateUpdateData: StateDataSchemeInterface<TScheme> = {};
+  const stateUpdateData: IStateDataScheme<TScheme> = {};
 
   if (scheme) {
     Object.keys(scheme).forEach((keyName: string) => {
@@ -54,7 +54,7 @@ export const buildInitialState = <TData, TFilter, TScheme>(
     TFilter,
     TScheme
   >,
-  scheme: SchemeInterface<TScheme> | null | undefined
+  scheme: IScheme<TScheme> | null | undefined
 ) => {
   state.update = generateInitialState<TData, TScheme>(scheme);
 };
@@ -188,17 +188,17 @@ export const buildActions = <TData, TFilter, TScheme>(
     }
 
     const state = Object.keys(mapData).reduce(
-      (acc: StateDataSchemeInterface<TScheme>, keyName: string) => {
+      (acc: IStateDataScheme<TScheme>, keyName: string) => {
         const key = keyName as keyof TScheme;
 
         acc[key] = updateData[key];
         return acc;
       },
-      {} as StateDataSchemeInterface<TScheme>
+      {} as IStateDataScheme<TScheme>
     );
 
     const stateValues = Object.values(state) as Array<
-      StateFieldSchemeInterface<keyof TScheme>
+      IStateFieldScheme<keyof TScheme>
     >;
 
     for (const stateItem of stateValues) {
@@ -213,7 +213,7 @@ export const buildActions = <TData, TFilter, TScheme>(
     // received result must be sent to backend, otherwise state values will
     // be used to send to backend.
     if (typeof interceptors.beforeSend === 'function') {
-      const beforeSendCall = interceptors.beforeSend as BeforeSendInterface<
+      const beforeSendCall = interceptors.beforeSend as IBeforeSend<
         TData,
         TScheme
       >;

--- a/clients/app/src/stores/generateCRUD/docs/1-generate-store.md
+++ b/clients/app/src/stores/generateCRUD/docs/1-generate-store.md
@@ -11,10 +11,10 @@ The function receives a tree generic types
 Example:
 
 ```typescript
-import { generateCRUD, Filterable, InitStoreParamsInterface } from './generateCRUD';
+import { generateCRUD, Filterable, IInitStoreParams } from './generateCRUD';
 import { FanClubViewModel, FilterFanClub } from '@app/view-models';
 
-type ParamType<TScheme> = InitStoreParamsInterface<TData, TScheme>;
+type ParamType<TScheme> = IInitStoreParams<TData, TScheme>;
 
 type TFilter = Filterable<FilterFanClub>>;
 type TKey = 'list' | 'single' | 'add' | 'update' | 'delete';
@@ -42,7 +42,7 @@ const store = storeBuilder();
 Available options:
 
 ```typescript
-interface PropsInterface<TData, TKey, TFilter> {
+interface IProps<TData, TKey, TFilter> {
   // common
   keys?: Array<TKey>;
 
@@ -54,8 +54,8 @@ interface PropsInterface<TData, TKey, TFilter> {
   loadSingle(id: ResourceIdentifier): GetSinglePromiseType<TData>;
 
   // add
-  scheme: SchemeInterface;
-  beforeSend: BeforeSendInterface<TData> | null;
+  scheme: IScheme;
+  beforeSend: IBeforeSend<TData> | null;
   create(data: Partial<TData>): CreatePromiseType<TData>;
 }
 ```

--- a/clients/app/src/stores/generateCRUD/docs/3.1-list.md
+++ b/clients/app/src/stores/generateCRUD/docs/3.1-list.md
@@ -3,7 +3,7 @@
 The `list` state key has following type:
 
 ```typescript
-interface ListStateDataInterface<TData, TFilter> {
+interface IListStateData<TData, TFilter> {
   status: StatusType;
   error: null | Error;
   data: null | Array<TData>;
@@ -20,7 +20,7 @@ interface ListStateDataInterface<TData, TFilter> {
 CRUD generator excepting following API response:
 
 ```typescript
-interface ApiListResponseInterface<TModel> {
+interface IApiListResponse<TModel> {
   data: Array<TModel>;
   meta: {
     pagination: {

--- a/clients/app/src/stores/generateCRUD/docs/3.2-single.md
+++ b/clients/app/src/stores/generateCRUD/docs/3.2-single.md
@@ -3,7 +3,7 @@
 The `single` state key has following type:
 
 ```typescript
-interface SingleStateDataInterface<TData> {
+interface ISingleStateData<TData> {
   status: StatusType;
   error: null | Error;
   data: null | TData;
@@ -13,7 +13,7 @@ interface SingleStateDataInterface<TData> {
 CRUD generator excepting following API response:
 
 ```typescript
-interface ApiSingleResponseInterface<TModel> {
+interface IApiSingleResponse<TModel> {
   data: TModel;
   meta: {};
 }

--- a/clients/app/src/stores/generateCRUD/docs/3.3-add.md
+++ b/clients/app/src/stores/generateCRUD/docs/3.3-add.md
@@ -3,20 +3,20 @@
 The `add` state key has following type:
 
 ```typescript
-interface StateFieldAddInterface<TFieldValue = string> {
+interface IStateFieldAdd<TFieldValue = string> {
   isValid: boolean;
   valueOriginal: TFieldValue | null;
   valueToSave: TFieldValue | null;
   errors: Array<string>;
 }
-interface StateDataAddInterface<TFieldValue = string> {
-  [key: string]: StateFieldAddInterface<TFieldValue>;
+interface IStateDataAdd<TFieldValue = string> {
+  [key: string]: IStateFieldAdd<TFieldValue>;
 }
 
-interface AddStateDataInterface<TData> {
+interface IAddStateData<TData> {
   status: StatusType;
   error: null | Error;
-  data: null | StateDataAddInterface;
+  data: null | IStateDataAdd;
   valid: boolean;
 }
 ```
@@ -24,7 +24,7 @@ interface AddStateDataInterface<TData> {
 CRUD generator excepting following API response:
 
 ```typescript
-interface ApiSingleResponseInterface<TModel> {
+interface IApiSingleResponse<TModel> {
   data: TModel;
   meta: {};
 }
@@ -38,7 +38,7 @@ When `add` key provided, the system will add `add` state, `create` and `setAddFi
 Scheme interface:
 
 ```typescript
-interface SchemeFieldInterface<TFieldValue = string> {
+interface ISchemeField<TFieldValue = string> {
   initialValue?: TFieldValue | null;
   processValue?(valueOriginal: TFieldValue | null): TFieldValue;
   validate?(
@@ -47,8 +47,8 @@ interface SchemeFieldInterface<TFieldValue = string> {
   ): Array<string>;
 }
 
-type SchemeInterface<T> = {
-  [TKey in keyof T]: SchemeFieldInterface<T[TKey]>;
+type IScheme<T> = {
+  [TKey in keyof T]: ISchemeField<T[TKey]>;
 }
 ```
 
@@ -62,12 +62,12 @@ Example:
 ```typescript
 // ...
 
-interface DataSchemeInterface {
+interface IDataScheme {
   name: string;
   description: string;
 }
 
-const scheme: SchemeInterface<DataSchemeInterface> = {
+const scheme: IScheme<IDataScheme> = {
   name: {
     processValue: (valueOriginal: string) => {
       return valueOriginal.trim();

--- a/clients/app/src/stores/generateCRUD/docs/3.4-update.md
+++ b/clients/app/src/stores/generateCRUD/docs/3.4-update.md
@@ -3,21 +3,21 @@
 The `update` state key has following type:
 
 ```typescript
-interface StateFieldUpdateInterface<TFieldValue = string> {
+interface IStateFieldUpdate<TFieldValue = string> {
   isValid: boolean;
   valueOriginal: TFieldValue | null;
   valueToSave: TFieldValue | null;
   errors: Array<string>;
 }
-interface StateDataUpdateInterface<TFieldValue = string> {
-  [key: string]: StateFieldUpdateInterface<TFieldValue>;
+interface IStateDataUpdate<TFieldValue = string> {
+  [key: string]: IStateFieldUpdate<TFieldValue>;
 }
 
-interface UpdateStateDataInterface<TData> {
+interface IUpdateStateData<TData> {
   status: StatusType;
   resourceId: null | ResourceIdentifier;
   error: null | Error;
-  data: null | StateDataUpdateInterface;
+  data: null | IStateDataUpdate;
   valid: boolean;
 }
 ```
@@ -25,7 +25,7 @@ interface UpdateStateDataInterface<TData> {
 CRUD generator excepting following API response:
 
 ```typescript
-interface ApiSingleResponseInterface<TModel> {
+interface IApiSingleResponse<TModel> {
   data: TModel;
   meta: {};
 }
@@ -39,7 +39,7 @@ When `update` key provided, the system will add `update` state, `updateData` and
 Scheme interface:
 
 ```typescript
-interface SchemeFieldInterface<TFieldValue = string> {
+interface ISchemeField<TFieldValue = string> {
   initialValue?: TFieldValue | null;
   processValue?(valueOriginal: TFieldValue | null): TFieldValue;
   validate?(
@@ -48,8 +48,8 @@ interface SchemeFieldInterface<TFieldValue = string> {
   ): Array<string>;
 }
 
-type SchemeInterface<T> = {
-  [TKey in keyof T]: SchemeFieldInterface<T[TKey]>;
+type IScheme<T> = {
+  [TKey in keyof T]: ISchemeField<T[TKey]>;
 }
 ```
 
@@ -63,12 +63,12 @@ Example:
 ```typescript
 // ...
 
-interface DataSchemeInterface {
+interface IDataScheme {
   name: string;
   description: string;
 }
 
-const scheme: SchemeInterface<DataSchemeInterface> = {
+const scheme: IScheme<IDataScheme> = {
   name: {
     processValue: (valueOriginal: string) => {
       return valueOriginal.trim();

--- a/clients/app/src/stores/generateCRUD/types/crud/add.ts
+++ b/clients/app/src/stores/generateCRUD/types/crud/add.ts
@@ -1,22 +1,22 @@
 import type { ApiResponseType } from '@ultras/core-api-sdk';
 import type { StatusType } from '../common';
 import {
-  StateDataSchemeInterface,
-  SchemeInterface,
-  BeforeSendInterface,
+  IStateDataScheme,
+  IScheme,
+  IBeforeSend,
 } from '../scheme';
 
 type CreatePromiseType<TData> = undefined | Promise<ApiResponseType<TData>>;
 
-export interface AddStateDataInterface<TData, TScheme> {
+export interface IAddStateData<TData, TScheme> {
   status: StatusType;
   error: null | Error;
-  data: null | StateDataSchemeInterface<TScheme>;
+  data: null | IStateDataScheme<TScheme>;
   valid: boolean;
 }
 
 export interface AddGroupedStateType<TData, TScheme> {
-  add: AddStateDataInterface<TData, TScheme>;
+  add: IAddStateData<TData, TScheme>;
 }
 
 export type AddGroupedActionType<TData> = {
@@ -29,7 +29,7 @@ export type AddGroupedActionType<TData> = {
 };
 
 export type AddGroupedInterceptorType<TData, TScheme> = {
-  scheme: SchemeInterface<TScheme>;
-  beforeSend: BeforeSendInterface<TData, TScheme> | null;
+  scheme: IScheme<TScheme>;
+  beforeSend: IBeforeSend<TData, TScheme> | null;
   create(data: Partial<TData>): CreatePromiseType<TData>;
 };

--- a/clients/app/src/stores/generateCRUD/types/crud/delete.ts
+++ b/clients/app/src/stores/generateCRUD/types/crud/delete.ts
@@ -1,15 +1,15 @@
-import { ResponseInterface } from '@ultras/core-api-sdk/build/types';
+import { IResponse } from '@ultras/core-api-sdk/build/types';
 import type { StatusType } from '../common';
 
-type DeletePromiseType = undefined | Promise<void | ResponseInterface>;
+type DeletePromiseType = undefined | Promise<void | IResponse>;
 
-export interface DeleteStateDataInterface<TData> {
+export interface IDeleteStateData<TData> {
   status: StatusType;
   error: null | Error;
 }
 
 export interface DeleteGroupedStateType<TData> {
-  delete: DeleteStateDataInterface<TData>;
+  delete: IDeleteStateData<TData>;
 }
 
 export type DeleteGroupedActionType<TData> = {

--- a/clients/app/src/stores/generateCRUD/types/crud/list.ts
+++ b/clients/app/src/stores/generateCRUD/types/crud/list.ts
@@ -5,7 +5,7 @@ type GetListPromiseType<TData> =
   | undefined
   | Promise<ApiResponseType<Array<TData>, ListResponseMetaType>>;
 
-export interface ListStateDataInterface<TData, TFilter> {
+export interface IListStateData<TData, TFilter> {
   status: StatusType;
   error: null | Error;
   data: null | Array<TData>;
@@ -19,11 +19,11 @@ export interface ListStateDataInterface<TData, TFilter> {
 }
 
 export interface ListGroupedStateType<TData, TFilter> {
-  list: ListStateDataInterface<TData, TFilter>;
+  list: IListStateData<TData, TFilter>;
 }
 
 export type ListGroupedActionType<TData, TFilter> = {
-  getAll(): Promise<ListStateDataInterface<TData, TFilter>>;
+  getAll(): Promise<IListStateData<TData, TFilter>>;
   updateFilter(filter: Partial<TFilter>): void;
   reset(): void;
 };

--- a/clients/app/src/stores/generateCRUD/types/crud/single.ts
+++ b/clients/app/src/stores/generateCRUD/types/crud/single.ts
@@ -3,18 +3,18 @@ import type { StatusType } from '../common';
 
 type GetSinglePromiseType<TData> = undefined | Promise<ApiResponseType<TData>>;
 
-export interface SingleStateDataInterface<TData> {
+export interface ISingleStateData<TData> {
   status: StatusType;
   error: null | Error;
   data: null | TData;
 }
 
 export interface SingleGroupedStateType<TData> {
-  single: SingleStateDataInterface<TData>;
+  single: ISingleStateData<TData>;
 }
 
 export type SingleGroupedActionType<TData> = {
-  getSingle(id: ResourceIdentifier): Promise<SingleStateDataInterface<TData>>;
+  getSingle(id: ResourceIdentifier): Promise<ISingleStateData<TData>>;
   reset(): void;
 };
 

--- a/clients/app/src/stores/generateCRUD/types/crud/update.ts
+++ b/clients/app/src/stores/generateCRUD/types/crud/update.ts
@@ -1,23 +1,23 @@
 import type { ApiResponseType } from '@ultras/core-api-sdk';
 import type { StatusType } from '../common';
 import {
-  StateDataSchemeInterface,
-  SchemeInterface,
-  BeforeSendInterface,
+  IStateDataScheme,
+  IScheme,
+  IBeforeSend,
 } from '../scheme';
 
 type CreatePromiseType<TData> = undefined | Promise<ApiResponseType<TData>>;
 
-export interface UpdateStateDataInterface<TData, TScheme> {
+export interface IUpdateStateData<TData, TScheme> {
   status: StatusType;
   resourceId: Nullable<ResourceIdentifier>;
   error: null | Error;
-  data: null | StateDataSchemeInterface<TScheme>;
+  data: null | IStateDataScheme<TScheme>;
   valid: boolean;
 }
 
 export interface UpdateGroupedStateType<TData, TScheme> {
-  update: UpdateStateDataInterface<TData, TScheme>;
+  update: IUpdateStateData<TData, TScheme>;
 }
 
 export type UpdateGroupedActionType<TData> = {
@@ -31,8 +31,8 @@ export type UpdateGroupedActionType<TData> = {
 };
 
 export type UpdateGroupedInterceptorType<TData, TScheme> = {
-  scheme: SchemeInterface<TScheme>;
-  beforeSend: BeforeSendInterface<TData, TScheme> | null;
+  scheme: IScheme<TScheme>;
+  beforeSend: IBeforeSend<TData, TScheme> | null;
   updateData(
     resourceId: Nullable<ResourceIdentifier>,
     data: Partial<TData>

--- a/clients/app/src/stores/generateCRUD/types/scheme.ts
+++ b/clients/app/src/stores/generateCRUD/types/scheme.ts
@@ -1,4 +1,4 @@
-export interface SchemeFieldInterface<TFieldValue> {
+export interface ISchemeField<TFieldValue> {
   initialValue?: TFieldValue | null;
   processValue?(valueOriginal: TFieldValue | null): TFieldValue;
   validate?(
@@ -7,21 +7,21 @@ export interface SchemeFieldInterface<TFieldValue> {
   ): Array<string>;
 }
 
-export type SchemeInterface<T> = {
-  [TKey in keyof T]: SchemeFieldInterface<T[TKey]>;
+export type IScheme<T> = {
+  [TKey in keyof T]: ISchemeField<T[TKey]>;
 };
 
-export interface BeforeSendInterface<TData, TScheme> {
-  (data: StateDataSchemeInterface<TScheme>): Partial<TData> | null;
+export interface IBeforeSend<TData, TScheme> {
+  (data: IStateDataScheme<TScheme>): Partial<TData> | null;
 }
 
-export interface StateFieldSchemeInterface<TFieldValue> {
+export interface IStateFieldScheme<TFieldValue> {
   isValid: boolean;
   valueOriginal: TFieldValue | null;
   valueToSave: TFieldValue | null;
   errors: Array<string>;
 }
 
-export type StateDataSchemeInterface<T> = {
-  [TKey in keyof T]: StateFieldSchemeInterface<T[TKey]>;
+export type IStateDataScheme<T> = {
+  [TKey in keyof T]: IStateFieldScheme<T[TKey]>;
 };

--- a/clients/app/src/stores/generateCRUD/types/store.ts
+++ b/clients/app/src/stores/generateCRUD/types/store.ts
@@ -1,6 +1,6 @@
 import type { StoreApi } from 'zustand/vanilla';
 import type { MergeUnion, StateKeyType } from './common';
-import type { BeforeSendInterface, SchemeInterface } from './scheme';
+import type { IBeforeSend, IScheme } from './scheme';
 import type {
   AddGroupedActionType,
   AddGroupedStateType,
@@ -49,9 +49,9 @@ export type RootStoreType<
   >
 >;
 
-export interface InitStoreParamsInterface<TDataViewModel, TScheme> {
-  scheme: SchemeInterface<TScheme>;
-  beforeSend: BeforeSendInterface<TDataViewModel, TScheme>;
+export interface IInitStoreParams<TDataViewModel, TScheme> {
+  scheme: IScheme<TScheme>;
+  beforeSend: IBeforeSend<TDataViewModel, TScheme>;
 }
 
 export type GroupedStateType<

--- a/clients/app/src/stores/generateCRUD/utils/helpers.ts
+++ b/clients/app/src/stores/generateCRUD/utils/helpers.ts
@@ -6,7 +6,7 @@ import type {
   ParamsType,
   StateGetterCallType,
   StateSetterCallType,
-  StateFieldSchemeInterface,
+  IStateFieldScheme,
   StateKeyType,
   StateKeyParamType,
   FullFilterable,
@@ -35,7 +35,7 @@ export function fillStateKeys(keys: Array<StateKeyType>): StateKeyParamType {
 
 export function createField<TFieldKey = string>(
   initialValue: TFieldKey | null = null
-): StateFieldSchemeInterface<TFieldKey> {
+): IStateFieldScheme<TFieldKey> {
   return {
     isValid: false,
     valueOriginal: initialValue,

--- a/clients/app/src/stores/matches.ts
+++ b/clients/app/src/stores/matches.ts
@@ -9,10 +9,10 @@ import {
   Filterable,
   FullFilterable,
   generateCRUD,
-  InitStoreParamsInterface,
+  IInitStoreParams,
 } from './generateCRUD';
 
-type ParamType<TScheme> = InitStoreParamsInterface<MatchViewModel, TScheme>;
+type ParamType<TScheme> = IInitStoreParams<MatchViewModel, TScheme>;
 type FilterType = Filterable<GetMatchesFilter>;
 
 const sdk = new MatchSDK('dev');

--- a/clients/app/src/stores/rooms.ts
+++ b/clients/app/src/stores/rooms.ts
@@ -8,10 +8,10 @@ import {
   Filterable,
   FullFilterable,
   generateCRUD,
-  InitStoreParamsInterface,
+  IInitStoreParams,
 } from './generateCRUD';
 
-type ParamType<TScheme> = InitStoreParamsInterface<RoomViewModel, TScheme>;
+type ParamType<TScheme> = IInitStoreParams<RoomViewModel, TScheme>;
 type FilterType = Filterable<GetRoomsFilter>;
 
 const sdk = new RoomSDK('dev');

--- a/clients/app/src/stores/teams.ts
+++ b/clients/app/src/stores/teams.ts
@@ -8,10 +8,10 @@ import {
   Filterable,
   FullFilterable,
   generateCRUD,
-  InitStoreParamsInterface,
+  IInitStoreParams,
 } from './generateCRUD';
 
-type ParamType<TScheme> = InitStoreParamsInterface<TeamViewModel, TScheme>;
+type ParamType<TScheme> = IInitStoreParams<TeamViewModel, TScheme>;
 type FilterType = Filterable<GetTeamsFilter>;
 
 const sdk = new TeamSDK('dev');

--- a/clients/app/src/stores/user.ts
+++ b/clients/app/src/stores/user.ts
@@ -1,7 +1,7 @@
 import { UserViewModel, UserSDK, ResourceIdentifier } from '@ultras/core-api-sdk';
-import { generateCRUD, InitStoreParamsInterface } from './generateCRUD';
+import { generateCRUD, IInitStoreParams } from './generateCRUD';
 
-type ParamType<TScheme> = InitStoreParamsInterface<UserViewModel, TScheme>;
+type ParamType<TScheme> = IInitStoreParams<UserViewModel, TScheme>;
 
 const sdk = new UserSDK('dev');
 

--- a/clients/app/src/themes/theming/configs.ts
+++ b/clients/app/src/themes/theming/configs.ts
@@ -1,6 +1,6 @@
-import { INativebaseConfig as ConfigInterface } from 'native-base';
+import { INativebaseConfig as IConfig } from 'native-base';
 
-const configs: ConfigInterface = {
+const configs: IConfig = {
   strictMode: 'warn',
   dependencies: {
     'linear-gradient': require('react-native-linear-gradient').default,

--- a/clients/app/src/views/components/base/Box/types.ts
+++ b/clients/app/src/views/components/base/Box/types.ts
@@ -3,7 +3,7 @@ import { StyleProp, ViewStyle } from 'react-native';
 import { ColorKey } from 'themes/types';
 
 export interface IBoxProps {
-  // theme: ThemeInterface;
+  // theme: ITheme;
   bgColor?: ColorKey;
   borderColor?: ColorKey;
   style?: StyleProp<ViewStyle>;

--- a/clients/app/src/views/components/compositions/FanClubInfo/FanClubJoinButton.tsx
+++ b/clients/app/src/views/components/compositions/FanClubInfo/FanClubJoinButton.tsx
@@ -9,7 +9,7 @@ import { IFanClubInfoProps } from './types';
 import ConfirmActionSheet from './actions/ConfirmActionSheet';
 import {
   buildButtonAttributes,
-  ButtonAttributeInterface,
+  IButtonAttribute,
 } from './actions/buttonAttributes';
 
 const FanClubJoinButton: React.FC<IFanClubInfoProps> = ({ data }) => {
@@ -155,7 +155,7 @@ const FanClubJoinButton: React.FC<IFanClubInfoProps> = ({ data }) => {
     }
   }, [joinStatus, data.privacy, storeAdd.status, storeDelete.status]);
 
-  const { icon, button } = React.useMemo((): ButtonAttributeInterface => {
+  const { icon, button } = React.useMemo((): IButtonAttribute => {
     if (joinStatus === FanClubMemberStatusEnum.active) {
       return buildButtonAttributes(joinStatus, theme.colors, onLeavePress);
     }

--- a/clients/app/src/views/components/compositions/FanClubInfo/actions/buttonAttributes.ts
+++ b/clients/app/src/views/components/compositions/FanClubInfo/actions/buttonAttributes.ts
@@ -2,17 +2,17 @@ import { FanClubMemberStatusEnum } from '@ultras/utils';
 import { ColorKey, ColorType } from 'themes/types';
 import { Icons } from 'assets/icons';
 
-interface OnButtonPressInterface {
+interface IOnButtonPress {
   (): void;
 }
 
-interface ButtonStyleInterface {
+interface IButtonStyle {
   bg: string;
   _pressed: { bg: string };
   _text: { color: string };
 }
 
-export interface ButtonAttributeInterface {
+export interface IButtonAttribute {
   icon?: {
     name: Icons;
     color: ColorKey;
@@ -20,8 +20,8 @@ export interface ButtonAttributeInterface {
   button: {
     variant: string;
     text: string;
-    style: {} | ButtonStyleInterface;
-    onPress?: OnButtonPressInterface;
+    style: {} | IButtonStyle;
+    onPress?: IOnButtonPress;
   };
 }
 
@@ -30,7 +30,7 @@ function buildStyle(
   initial: ColorKey,
   pressed: ColorKey,
   text: ColorKey
-): ButtonStyleInterface {
+): IButtonStyle {
   return {
     bg: colors[initial],
     _pressed: {
@@ -45,8 +45,8 @@ function buildStyle(
 export function buildButtonAttributes(
   joinStatus: FanClubMemberStatusEnum,
   colors: ColorType,
-  onButtonPress?: OnButtonPressInterface
-): ButtonAttributeInterface {
+  onButtonPress?: IOnButtonPress
+): IButtonAttribute {
 
   // active - means user already in fan club's member list.
   if (joinStatus === FanClubMemberStatusEnum.active) {

--- a/packages/services/MailerService/index.ts
+++ b/packages/services/MailerService/index.ts
@@ -1,8 +1,8 @@
 import * as sendGrid from '@sendgrid/mail';
 import {
-  SendEmailSingleOptionsInterface,
-  SendEmailMultipleOptionsInterface,
-  SendEmailFinalOptionsInterface,
+  ISendEmailSingleOptions,
+  ISendEmailMultipleOptions,
+  ISendEmailFinalOptions,
   FromType,
   ResultType,
 } from './types';
@@ -28,7 +28,7 @@ class MailerService {
     sendGrid.setApiKey(this.sendGridApiKey);
   }
 
-  private async sendEmail(options: SendEmailSingleOptionsInterface): Promise<ResultType> {
+  private async sendEmail(options: ISendEmailSingleOptions): Promise<ResultType> {
     if ('undefined' === typeof options.from) {
       options.from = this.defaultSender || '';
     }
@@ -37,22 +37,22 @@ class MailerService {
       options.from = `${options.from.name} <${options.from.email}>`;
     }
 
-    return sendGrid.send(options as SendEmailFinalOptionsInterface, false);
+    return sendGrid.send(options as ISendEmailFinalOptions, false);
   }
 
-  static async send(options: SendEmailSingleOptionsInterface): Promise<ResultType> {
+  static async send(options: ISendEmailSingleOptions): Promise<ResultType> {
     return this.singleton().send(options);
   }
 
-  async send(options: SendEmailSingleOptionsInterface): Promise<ResultType> {
+  async send(options: ISendEmailSingleOptions): Promise<ResultType> {
     return this.sendEmail(options);
   }
 
-  static async sendMultiple(options: SendEmailMultipleOptionsInterface, viaBcc = true) {
+  static async sendMultiple(options: ISendEmailMultipleOptions, viaBcc = true) {
     return this.singleton().sendMultiple(options);
   }
 
-  async sendMultiple(options: SendEmailMultipleOptionsInterface, viaBcc = true) {
+  async sendMultiple(options: ISendEmailMultipleOptions, viaBcc = true) {
     if (!Array.isArray(options.to)) {
       options.to = [options.to];
     }
@@ -62,7 +62,7 @@ class MailerService {
       to: options.to[0],
     };
 
-    const newOptions = optionsClone as SendEmailFinalOptionsInterface;
+    const newOptions = optionsClone as ISendEmailFinalOptions;
     options.to.slice(1).forEach(email => {
       if (viaBcc) {
         newOptions.bcc = newOptions.bcc || [];

--- a/packages/services/MailerService/types.ts
+++ b/packages/services/MailerService/types.ts
@@ -3,32 +3,30 @@ import { ClientResponse } from '@sendgrid/mail';
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type ResultType = [ClientResponse, {}];
 
-interface FromInterface {
+interface IFrom {
   name: string;
   email: string;
 }
 
-export type FromType = string | FromInterface;
+export type FromType = string | IFrom;
 
-interface SendEmailCommonOptionsInterface {
+interface ISendEmailCommonOptions {
   from?: FromType;
   subject: string;
   html: string;
 }
 
-export interface SendEmailFinalOptionsInterface
-  extends Omit<SendEmailCommonOptionsInterface, 'from'> {
+export interface ISendEmailFinalOptions extends Omit<ISendEmailCommonOptions, 'from'> {
   from: FromType;
   to: string;
   cc?: string[];
   bcc?: string[];
 }
 
-export interface SendEmailSingleOptionsInterface extends SendEmailCommonOptionsInterface {
+export interface ISendEmailSingleOptions extends ISendEmailCommonOptions {
   to: string;
 }
 
-export interface SendEmailMultipleOptionsInterface
-  extends SendEmailCommonOptionsInterface {
+export interface ISendEmailMultipleOptions extends ISendEmailCommonOptions {
   to: string[];
 }

--- a/packages/services/NetworkService/index.ts
+++ b/packages/services/NetworkService/index.ts
@@ -12,7 +12,7 @@ import exceptionDetector from './interceptors/exceptionDetector';
 
 import 'isomorphic-fetch';
 
-interface RequestResultInterface {
+interface IRequestResult {
   headers?: any;
   json?: any;
   status?: any;
@@ -23,7 +23,7 @@ export type ResponseBodyType<TBody> = TBody & {
   success?: boolean;
 };
 
-export interface ResponseInterface<TBody = any, THeaders = any> {
+export interface IResponse<TBody = any, THeaders = any> {
   headers: THeaders;
   body: ResponseBodyType<TBody>;
 }
@@ -140,7 +140,7 @@ class NetworkService {
   makeAPIRequest = <TBody = any, THeaders = any>(
     partUrl: string,
     options: RequestOptions = {}
-  ): Promise<ResponseInterface<TBody, THeaders>> => {
+  ): Promise<IResponse<TBody, THeaders>> => {
     return new Promise(async (resolve, reject) => {
       let url = this.createUrl(partUrl);
 
@@ -157,7 +157,7 @@ class NetworkService {
       }
 
       this.request(url, options)
-        .then(async (response: RequestResultInterface) => {
+        .then(async (response: IRequestResult) => {
           if (!response) {
             return reject({
               message: HttpErrorMessages.INVALID_RESPONSE_DATA,

--- a/packages/services/SMSService/index.ts
+++ b/packages/services/SMSService/index.ts
@@ -1,5 +1,5 @@
 import { Twilio as TwilioClient } from 'twilio';
-import { SendSMSMultipleOptionsInterface, SendSMSOptionsInterface } from './types';
+import { ISendSMSMultipleOptions, ISendSMSOptions } from './types';
 
 class SMSService {
   private static staticInstance: null | SMSService = null;
@@ -36,11 +36,11 @@ class SMSService {
     this.client = new TwilioClient(this.accountSid, this.authToken);
   }
 
-  static async send(options: SendSMSOptionsInterface) {
+  static async send(options: ISendSMSOptions) {
     return this.singleton().send(options);
   }
 
-  async send(options: SendSMSOptionsInterface) {
+  async send(options: ISendSMSOptions) {
     const optionsClone = { ...options };
     if (!optionsClone.messagingServiceSid) {
       optionsClone.messagingServiceSid = this.defaultMessageServiceId || '';
@@ -54,14 +54,14 @@ class SMSService {
     });
   }
 
-  static async sendMultiple(options: SendSMSMultipleOptionsInterface) {
+  static async sendMultiple(options: ISendSMSMultipleOptions) {
     return this.singleton().sendMultiple(options);
   }
 
-  async sendMultiple(options: SendSMSMultipleOptionsInterface) {
+  async sendMultiple(options: ISendSMSMultipleOptions) {
     const results = [];
     for (let i = 0; i < options.to.length; ++i) {
-      const itemOptions: SendSMSOptionsInterface = {
+      const itemOptions: ISendSMSOptions = {
         ...options,
         to: options.to[i],
       };

--- a/packages/services/SMSService/types.ts
+++ b/packages/services/SMSService/types.ts
@@ -1,11 +1,10 @@
-export interface SendSMSOptionsInterface {
+export interface ISendSMSOptions {
   from?: string;
   messagingServiceSid?: string;
   to: string;
   body: string;
 }
 
-export interface SendSMSMultipleOptionsInterface
-  extends Omit<SendSMSOptionsInterface, 'to'> {
+export interface ISendSMSMultipleOptions extends Omit<ISendSMSOptions, 'to'> {
   to: Array<string>;
 }

--- a/sdks/core-api-sdk/src/sdks/CoreApiBaseSDK.ts
+++ b/sdks/core-api-sdk/src/sdks/CoreApiBaseSDK.ts
@@ -1,5 +1,5 @@
 import NetworkService from '@ultras/services/NetworkService';
-import type { ResponseInterface } from '@ultras/services/NetworkService';
+import type { IResponse } from '@ultras/services/NetworkService';
 import { Interceptor } from '@ultras/services/NetworkService/types';
 import { AuthTokenInterceptor } from '../interceptors';
 import configs from '../configs';
@@ -7,7 +7,7 @@ import type { ApiResponseType, ListResponseMetaType } from './types';
 import { DynamicQueryParam, QueryParam } from './types';
 
 export type Mode = 'dev' | 'staging' | 'production';
-export { ApiResponseType, ListResponseMetaType, ResponseInterface };
+export { ApiResponseType, ListResponseMetaType, IResponse };
 
 abstract class CoreApiBaseSDK {
   protected api: NetworkService | undefined;

--- a/sdks/core-api-sdk/src/sdks/EventSDK/index.ts
+++ b/sdks/core-api-sdk/src/sdks/EventSDK/index.ts
@@ -1,6 +1,6 @@
 import CoreApiBaseSDK, { Mode } from '../CoreApiBaseSDK';
-import CommentableInterface from '../CommentableInterface';
-import LikeableInterface from '../LikeableInterface';
+import ICommentable from '../ICommentable';
+import ILikeable from '../ILikeable';
 import type { QueryParam, ResourceIdentifier } from '../types';
 import type {
   GetEventsFilter,
@@ -14,10 +14,7 @@ import type {
 
 export * from './types';
 
-export class EventSDK
-  extends CoreApiBaseSDK
-  implements LikeableInterface, CommentableInterface
-{
+export class EventSDK extends CoreApiBaseSDK implements ILikeable, ICommentable {
   constructor(mode?: Mode) {
     super(mode, 'events');
   }

--- a/sdks/core-api-sdk/src/sdks/ICommentable.ts
+++ b/sdks/core-api-sdk/src/sdks/ICommentable.ts
@@ -1,9 +1,9 @@
-import type { ResponseInterface } from './CoreApiBaseSDK';
+import type { IResponse } from './CoreApiBaseSDK';
 import type { ResourceIdentifier } from './types';
 
-type Return<TBody, THeaders> = undefined | Promise<ResponseInterface<TBody, THeaders>>;
+type Return<TBody, THeaders> = undefined | Promise<IResponse<TBody, THeaders>>;
 
-interface CommentableInterface {
+interface ICommentable {
   getComments<TBody, THeaders>(resourceId: ResourceIdentifier): Return<TBody, THeaders>;
 
   addComment<TBody, THeaders>(
@@ -23,4 +23,4 @@ interface CommentableInterface {
   ): Return<TBody, THeaders>;
 }
 
-export default CommentableInterface;
+export default ICommentable;

--- a/sdks/core-api-sdk/src/sdks/ILikeable.ts
+++ b/sdks/core-api-sdk/src/sdks/ILikeable.ts
@@ -1,12 +1,12 @@
-import type { ResponseInterface } from './CoreApiBaseSDK';
+import type { IResponse } from './CoreApiBaseSDK';
 import type { ResourceIdentifier } from './types';
 
-type Return<TBody, THeaders> = undefined | Promise<ResponseInterface<TBody, THeaders>>;
+type Return<TBody, THeaders> = undefined | Promise<IResponse<TBody, THeaders>>;
 
-interface LikeableInterface {
+interface ILikeable {
   getLikes<TBody, THeaders>(resourceId: ResourceIdentifier): Return<TBody, THeaders>;
   like<TBody, THeaders>(resourceId: ResourceIdentifier): Return<TBody, THeaders>;
   unlike<TBody, THeaders>(resourceId: ResourceIdentifier): Return<TBody, THeaders>;
 }
 
-export default LikeableInterface;
+export default ILikeable;

--- a/sdks/core-api-sdk/src/sdks/MatchSDK/index.ts
+++ b/sdks/core-api-sdk/src/sdks/MatchSDK/index.ts
@@ -1,13 +1,13 @@
 import { timezone } from '@ultras/utils';
 
 import CoreApiBaseSDK, { Mode } from '../CoreApiBaseSDK';
-import LikeableInterface from '../LikeableInterface';
+import ILikeable from '../ILikeable';
 import type { QueryParam, ResourceIdentifier } from '../types';
 import type { GetMatchesFilter, GetMatchesResponse, GetMatchResponse } from './types';
 
 export * from './types';
 
-export class MatchSDK extends CoreApiBaseSDK implements LikeableInterface {
+export class MatchSDK extends CoreApiBaseSDK implements ILikeable {
   constructor(mode?: Mode) {
     super(mode, 'matches');
   }

--- a/sdks/core-api-sdk/src/sdks/RoomSDK/index.ts
+++ b/sdks/core-api-sdk/src/sdks/RoomSDK/index.ts
@@ -1,5 +1,5 @@
 import CoreApiBaseSDK, { Mode } from '../CoreApiBaseSDK';
-import LikeableInterface from '../LikeableInterface';
+import ILikeable from '../ILikeable';
 import type { QueryParam, ResourceIdentifier } from '../types';
 import type {
   GetRoomsFilter,
@@ -13,7 +13,7 @@ import type {
 
 export * from './types';
 
-export class RoomSDK extends CoreApiBaseSDK implements LikeableInterface {
+export class RoomSDK extends CoreApiBaseSDK implements ILikeable {
   constructor(mode?: Mode) {
     super(mode, 'rooms');
   }

--- a/sdks/core-api-sdk/src/sdks/UltrasS3SDK/index.ts
+++ b/sdks/core-api-sdk/src/sdks/UltrasS3SDK/index.ts
@@ -1,9 +1,9 @@
 import { HttpRequestMethods } from '@ultras/services/NetworkService/types';
 import CoreApiBaseSDK, { Mode } from '../CoreApiBaseSDK';
 import type {
-  SigningUrlParamsInterface,
-  UploadViaSignedUrlParamsInterface,
-  UploadParamsInterface,
+  ISigningUrlParams,
+  IUploadViaSignedUrlParams,
+  IUploadParams,
 } from './types';
 export * from './types';
 
@@ -15,7 +15,7 @@ export class UltrasS3SDK extends CoreApiBaseSDK {
   /**
    * Will generate a file path and signed url to upload into AWS S3.
    */
-  public getSignedUrl(params: SigningUrlParamsInterface) {
+  public getSignedUrl(params: ISigningUrlParams) {
     return this.api?.makeAPIGetRequest('signed-url', {
       query_params: this.buildQueryParam(params),
     });
@@ -25,7 +25,7 @@ export class UltrasS3SDK extends CoreApiBaseSDK {
    * File must be uploaded to AWS S3 using pre-signed url.
    * Just provide a file instance and pre-signed url.
    */
-  public uploadViaSignedUrl(params: UploadViaSignedUrlParamsInterface) {
+  public uploadViaSignedUrl(params: IUploadViaSignedUrlParams) {
     return this.api?.request(params.signedUrl, {
       body: params.file,
       method: HttpRequestMethods.PUT,
@@ -37,7 +37,7 @@ export class UltrasS3SDK extends CoreApiBaseSDK {
    * after that it will be upload file to AWS S3 using pre-signed url
    * and give you back saved file path.
    */
-  public async upload(params: UploadParamsInterface) {
+  public async upload(params: IUploadParams) {
     const extension = params.file.name.split('.').pop() || '';
     const responseSigning = await this.getSignedUrl({
       folder: params.folder,

--- a/sdks/core-api-sdk/src/sdks/UltrasS3SDK/types.ts
+++ b/sdks/core-api-sdk/src/sdks/UltrasS3SDK/types.ts
@@ -1,14 +1,14 @@
-export interface SigningUrlParamsInterface {
+export interface ISigningUrlParams {
   folder: string;
   extension: string;
 }
 
-export interface UploadViaSignedUrlParamsInterface {
+export interface IUploadViaSignedUrlParams {
   file: File;
   signedUrl: string;
 }
 
-export interface UploadParamsInterface {
+export interface IUploadParams {
   file: File;
   folder: string;
 }

--- a/sdks/core-api-sdk/src/sdks/UserSDK/index.ts
+++ b/sdks/core-api-sdk/src/sdks/UserSDK/index.ts
@@ -1,9 +1,9 @@
 import CoreApiBaseSDK, { Mode } from '../CoreApiBaseSDK';
 import {
-  ConfirmIdentityInterface,
-  VerifyCodeInterface,
-  RegistrationInterface,
-  LoginInterface,
+  IConfirmIdentity,
+  IVerifyCode,
+  IRegistration,
+  ILogin,
   ConfirmIdentityResponse,
   VerifyCodeResponse,
   CheckUserExistenceResponse,
@@ -31,13 +31,13 @@ export class UserSDK extends CoreApiBaseSDK {
     AuthTokenInterceptor.onTokenUpdate(callback);
   }
 
-  public confirmIdentity(params: ConfirmIdentityInterface) {
+  public confirmIdentity(params: IConfirmIdentity) {
     return this.api?.makeAPIPostRequest<ConfirmIdentityResponse>('identity-confirm', {
       body: params,
     });
   }
 
-  public verifyCode(params: VerifyCodeInterface) {
+  public verifyCode(params: IVerifyCode) {
     return this.api?.makeAPIPostRequest<VerifyCodeResponse>('verify-code', {
       body: params,
     });
@@ -52,13 +52,13 @@ export class UserSDK extends CoreApiBaseSDK {
     );
   }
 
-  public register(params: RegistrationInterface) {
+  public register(params: IRegistration) {
     return this.api?.makeAPIPostRequest<LoginResponse>('register', {
       body: params,
     });
   }
 
-  public login(params: LoginInterface) {
+  public login(params: ILogin) {
     return this.api?.makeAPIPostRequest<LoginResponse>('login', {
       body: params,
     });

--- a/sdks/core-api-sdk/src/sdks/UserSDK/types.ts
+++ b/sdks/core-api-sdk/src/sdks/UserSDK/types.ts
@@ -2,27 +2,27 @@ import { NotifiedProviderEnum } from '@ultras/utils';
 import type { UserViewModel, BaseUserViewModel } from '@ultras/view-models';
 import type { ApiResponseBodyType, ResourceIdentifier } from '../types';
 
-interface PhoneOrEmailInterface {
+interface IPhoneOrEmail {
   phone?: string;
   email?: string;
 }
 
-interface CodeInterface {
+interface ICode {
   code: string;
 }
 
-export type ConfirmIdentityInterface = PhoneOrEmailInterface;
+export type IConfirmIdentity = IPhoneOrEmail;
 
-export interface VerifyCodeInterface extends PhoneOrEmailInterface, CodeInterface {}
+export interface IVerifyCode extends IPhoneOrEmail, ICode {}
 
-export interface RegistrationInterface extends PhoneOrEmailInterface, CodeInterface {
+export interface IRegistration extends IPhoneOrEmail, ICode {
   username: string;
   avatar?: string;
   fullname?: string;
   teamId?: ResourceIdentifier;
 }
 
-export interface LoginInterface extends PhoneOrEmailInterface, CodeInterface {}
+export interface ILogin extends IPhoneOrEmail, ICode {}
 
 export type ConfirmIdentityResponse = ApiResponseBodyType<{
   success: boolean;

--- a/sdks/core-api-sdk/src/sdks/index.ts
+++ b/sdks/core-api-sdk/src/sdks/index.ts
@@ -3,7 +3,7 @@ export {
   default as CoreApiBaseSdk,
   ApiResponseType,
   ListResponseMetaType,
-  ResponseInterface,
+  IResponse,
 } from './CoreApiBaseSDK';
 
 export * from './CountrySDK';

--- a/sdks/core-api-sdk/src/sdks/types.ts
+++ b/sdks/core-api-sdk/src/sdks/types.ts
@@ -3,7 +3,7 @@
 
 import { ListRequestParams } from '@ultras/utils';
 
-interface PossibleMetaInterface {
+interface IPossibleMeta {
   access_token?: string;
 }
 
@@ -39,7 +39,7 @@ type SuccessStatus =
   | 202 // accepted
   | 204; // no content
 
-export interface ErrorResponseInterface {
+export interface IErrorResponse {
   success: false;
   status: ClientErrorStatus | ServerErrorStatus;
   error: {
@@ -53,16 +53,16 @@ export interface ErrorResponseInterface {
   };
 }
 
-export interface SuccessResponseInterface<TBody = any, TMeta = {}> {
+export interface ISuccessResponse<TBody = any, TMeta = {}> {
   success: true;
   status: SuccessStatus;
   data: TBody;
-  meta: TMeta & PossibleMetaInterface;
+  meta: TMeta & IPossibleMeta;
 }
 
 export type ApiResponseBodyType<TBody = any, TMeta = {}> =
-  | ErrorResponseInterface
-  | SuccessResponseInterface<TBody, TMeta>;
+  | IErrorResponse
+  | ISuccessResponse<TBody, TMeta>;
 
 export type ApiResponseType<TBody = any, TMeta = any, THead = any> = {
   headers: THead;


### PR DESCRIPTION
#### All interfaces are renamed:
- `Interface` suffix was removed.
- `I` prefix was added.

---

#### Example:
`interface ResponseInterface {}` replaced with `interface IResponse {}`