### PR TITLE
[feat] attach image component

### DIFF
--- a/clients/app/ios/Podfile.lock
+++ b/clients/app/ios/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
     - React-Core
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.70.1)
-  - FBReactNativeSpec (0.70.1):
+  - FBLazyVector (0.70.2)
+  - FBReactNativeSpec (0.70.2):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired (= 0.70.1)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Core (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
+    - RCTRequired (= 0.70.2)
+    - RCTTypeSafety (= 0.70.2)
+    - React-Core (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - ReactCommon/turbomodule/core (= 0.70.2)
   - Flipper (0.159.0):
     - Flipper-Folly (~> 2.6)
   - Flipper-Boost-iOSX (1.76.0.1.11)
@@ -94,303 +94,305 @@ PODS:
     - fmt (~> 6.2.1)
     - glog
     - libevent
-  - RCTRequired (0.70.1)
-  - RCTTypeSafety (0.70.1):
-    - FBLazyVector (= 0.70.1)
-    - RCTRequired (= 0.70.1)
-    - React-Core (= 0.70.1)
-  - React (0.70.1):
-    - React-Core (= 0.70.1)
-    - React-Core/DevSupport (= 0.70.1)
-    - React-Core/RCTWebSocket (= 0.70.1)
-    - React-RCTActionSheet (= 0.70.1)
-    - React-RCTAnimation (= 0.70.1)
-    - React-RCTBlob (= 0.70.1)
-    - React-RCTImage (= 0.70.1)
-    - React-RCTLinking (= 0.70.1)
-    - React-RCTNetwork (= 0.70.1)
-    - React-RCTSettings (= 0.70.1)
-    - React-RCTText (= 0.70.1)
-    - React-RCTVibration (= 0.70.1)
-  - React-bridging (0.70.1):
+  - RCTRequired (0.70.2)
+  - RCTTypeSafety (0.70.2):
+    - FBLazyVector (= 0.70.2)
+    - RCTRequired (= 0.70.2)
+    - React-Core (= 0.70.2)
+  - React (0.70.2):
+    - React-Core (= 0.70.2)
+    - React-Core/DevSupport (= 0.70.2)
+    - React-Core/RCTWebSocket (= 0.70.2)
+    - React-RCTActionSheet (= 0.70.2)
+    - React-RCTAnimation (= 0.70.2)
+    - React-RCTBlob (= 0.70.2)
+    - React-RCTImage (= 0.70.2)
+    - React-RCTLinking (= 0.70.2)
+    - React-RCTNetwork (= 0.70.2)
+    - React-RCTSettings (= 0.70.2)
+    - React-RCTText (= 0.70.2)
+    - React-RCTVibration (= 0.70.2)
+  - React-bridging (0.70.2):
     - RCT-Folly (= 2021.07.22.00)
-    - React-jsi (= 0.70.1)
-  - React-callinvoker (0.70.1)
-  - React-Codegen (0.70.1):
-    - FBReactNativeSpec (= 0.70.1)
+    - React-jsi (= 0.70.2)
+  - React-callinvoker (0.70.2)
+  - React-Codegen (0.70.2):
+    - FBReactNativeSpec (= 0.70.2)
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired (= 0.70.1)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Core (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-Core (0.70.1):
+    - RCTRequired (= 0.70.2)
+    - RCTTypeSafety (= 0.70.2)
+    - React-Core (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - ReactCommon/turbomodule/core (= 0.70.2)
+  - React-Core (0.70.2):
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.70.1)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-Core/Default (= 0.70.2)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-perflogger (= 0.70.2)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.70.1):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
-    - Yoga
-  - React-Core/Default (0.70.1):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
-    - Yoga
-  - React-Core/DevSupport (0.70.1):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.70.1)
-    - React-Core/RCTWebSocket (= 0.70.1)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-jsinspector (= 0.70.1)
-    - React-perflogger (= 0.70.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.70.1):
+  - React-Core/CoreModulesHeaders (0.70.2):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-perflogger (= 0.70.2)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.70.1):
+  - React-Core/Default (0.70.2):
+    - glog
+    - RCT-Folly (= 2021.07.22.00)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-perflogger (= 0.70.2)
+    - Yoga
+  - React-Core/DevSupport (0.70.2):
+    - glog
+    - RCT-Folly (= 2021.07.22.00)
+    - React-Core/Default (= 0.70.2)
+    - React-Core/RCTWebSocket (= 0.70.2)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-jsinspector (= 0.70.2)
+    - React-perflogger (= 0.70.2)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.70.2):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-perflogger (= 0.70.2)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.70.1):
+  - React-Core/RCTAnimationHeaders (0.70.2):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-perflogger (= 0.70.2)
     - Yoga
-  - React-Core/RCTImageHeaders (0.70.1):
+  - React-Core/RCTBlobHeaders (0.70.2):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-perflogger (= 0.70.2)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.70.1):
+  - React-Core/RCTImageHeaders (0.70.2):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-perflogger (= 0.70.2)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.70.1):
+  - React-Core/RCTLinkingHeaders (0.70.2):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-perflogger (= 0.70.2)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.70.1):
+  - React-Core/RCTNetworkHeaders (0.70.2):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-perflogger (= 0.70.2)
     - Yoga
-  - React-Core/RCTTextHeaders (0.70.1):
+  - React-Core/RCTSettingsHeaders (0.70.2):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-perflogger (= 0.70.2)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.70.1):
+  - React-Core/RCTTextHeaders (0.70.2):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-perflogger (= 0.70.2)
     - Yoga
-  - React-Core/RCTWebSocket (0.70.1):
+  - React-Core/RCTVibrationHeaders (0.70.2):
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.70.1)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-Core/Default
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-perflogger (= 0.70.2)
     - Yoga
-  - React-CoreModules (0.70.1):
+  - React-Core/RCTWebSocket (0.70.2):
+    - glog
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Codegen (= 0.70.1)
-    - React-Core/CoreModulesHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-RCTImage (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-cxxreact (0.70.1):
+    - React-Core/Default (= 0.70.2)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-perflogger (= 0.70.2)
+    - Yoga
+  - React-CoreModules (0.70.2):
+    - RCT-Folly (= 2021.07.22.00)
+    - RCTTypeSafety (= 0.70.2)
+    - React-Codegen (= 0.70.2)
+    - React-Core/CoreModulesHeaders (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-RCTImage (= 0.70.2)
+    - ReactCommon/turbomodule/core (= 0.70.2)
+  - React-cxxreact (0.70.2):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsinspector (= 0.70.1)
-    - React-logger (= 0.70.1)
-    - React-perflogger (= 0.70.1)
-    - React-runtimeexecutor (= 0.70.1)
-  - React-hermes (0.70.1):
+    - React-callinvoker (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsinspector (= 0.70.2)
+    - React-logger (= 0.70.2)
+    - React-perflogger (= 0.70.2)
+    - React-runtimeexecutor (= 0.70.2)
+  - React-hermes (0.70.2):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - RCT-Folly/Futures (= 2021.07.22.00)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-jsinspector (= 0.70.1)
-    - React-perflogger (= 0.70.1)
-  - React-jsi (0.70.1):
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-jsiexecutor (= 0.70.2)
+    - React-jsinspector (= 0.70.2)
+    - React-perflogger (= 0.70.2)
+  - React-jsi (0.70.2):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-jsi/Default (= 0.70.1)
-  - React-jsi/Default (0.70.1):
+    - React-jsi/Default (= 0.70.2)
+  - React-jsi/Default (0.70.2):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-  - React-jsiexecutor (0.70.1):
+  - React-jsiexecutor (0.70.2):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-perflogger (= 0.70.1)
-  - React-jsinspector (0.70.1)
-  - React-logger (0.70.1):
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-perflogger (= 0.70.2)
+  - React-jsinspector (0.70.2)
+  - React-logger (0.70.2):
     - glog
   - react-native-blur (4.2.0):
     - React-Core
   - react-native-geolocation-service (5.3.1):
     - React
-  - react-native-pager-view (6.0.0):
+  - react-native-image-picker (4.10.0):
     - React-Core
-  - react-native-safe-area-context (4.3.4):
+  - react-native-pager-view (6.0.1):
+    - React-Core
+  - react-native-safe-area-context (4.4.1):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.70.1)
-  - React-RCTActionSheet (0.70.1):
-    - React-Core/RCTActionSheetHeaders (= 0.70.1)
-  - React-RCTAnimation (0.70.1):
+  - React-perflogger (0.70.2)
+  - React-RCTActionSheet (0.70.2):
+    - React-Core/RCTActionSheetHeaders (= 0.70.2)
+  - React-RCTAnimation (0.70.2):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTAnimationHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-RCTBlob (0.70.1):
+    - RCTTypeSafety (= 0.70.2)
+    - React-Codegen (= 0.70.2)
+    - React-Core/RCTAnimationHeaders (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - ReactCommon/turbomodule/core (= 0.70.2)
+  - React-RCTBlob (0.70.2):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTBlobHeaders (= 0.70.1)
-    - React-Core/RCTWebSocket (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-RCTNetwork (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-RCTImage (0.70.1):
+    - React-Codegen (= 0.70.2)
+    - React-Core/RCTBlobHeaders (= 0.70.2)
+    - React-Core/RCTWebSocket (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-RCTNetwork (= 0.70.2)
+    - ReactCommon/turbomodule/core (= 0.70.2)
+  - React-RCTImage (0.70.2):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTImageHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-RCTNetwork (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-RCTLinking (0.70.1):
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTLinkingHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-RCTNetwork (0.70.1):
+    - RCTTypeSafety (= 0.70.2)
+    - React-Codegen (= 0.70.2)
+    - React-Core/RCTImageHeaders (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-RCTNetwork (= 0.70.2)
+    - ReactCommon/turbomodule/core (= 0.70.2)
+  - React-RCTLinking (0.70.2):
+    - React-Codegen (= 0.70.2)
+    - React-Core/RCTLinkingHeaders (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - ReactCommon/turbomodule/core (= 0.70.2)
+  - React-RCTNetwork (0.70.2):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTNetworkHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-RCTSettings (0.70.1):
+    - RCTTypeSafety (= 0.70.2)
+    - React-Codegen (= 0.70.2)
+    - React-Core/RCTNetworkHeaders (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - ReactCommon/turbomodule/core (= 0.70.2)
+  - React-RCTSettings (0.70.2):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTSettingsHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-RCTText (0.70.1):
-    - React-Core/RCTTextHeaders (= 0.70.1)
-  - React-RCTVibration (0.70.1):
+    - RCTTypeSafety (= 0.70.2)
+    - React-Codegen (= 0.70.2)
+    - React-Core/RCTSettingsHeaders (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - ReactCommon/turbomodule/core (= 0.70.2)
+  - React-RCTText (0.70.2):
+    - React-Core/RCTTextHeaders (= 0.70.2)
+  - React-RCTVibration (0.70.2):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTVibrationHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-runtimeexecutor (0.70.1):
-    - React-jsi (= 0.70.1)
-  - ReactCommon/turbomodule/core (0.70.1):
+    - React-Codegen (= 0.70.2)
+    - React-Core/RCTVibrationHeaders (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - ReactCommon/turbomodule/core (= 0.70.2)
+  - React-runtimeexecutor (0.70.2):
+    - React-jsi (= 0.70.2)
+  - ReactCommon/turbomodule/core (0.70.2):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-bridging (= 0.70.1)
-    - React-callinvoker (= 0.70.1)
-    - React-Core (= 0.70.1)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-logger (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-bridging (= 0.70.2)
+    - React-callinvoker (= 0.70.2)
+    - React-Core (= 0.70.2)
+    - React-cxxreact (= 0.70.2)
+    - React-jsi (= 0.70.2)
+    - React-logger (= 0.70.2)
+    - React-perflogger (= 0.70.2)
   - RNCAsyncStorage (1.17.10):
     - React-Core
-  - RNDateTimePicker (6.3.4):
+  - RNDateTimePicker (6.5.0):
     - React-Core
   - RNI18n (2.0.15):
     - React
-  - RNScreens (3.17.0):
+  - RNScreens (3.18.1):
     - React-Core
     - React-RCTImage
-  - RNSVG (13.2.0):
+  - RNSVG (13.4.0):
     - React-Core
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
@@ -447,6 +449,7 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - "react-native-blur (from `../node_modules/@react-native-community/blur`)"
   - react-native-geolocation-service (from `../node_modules/react-native-geolocation-service`)
+  - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - react-native-pager-view (from `../node_modules/react-native-pager-view`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -535,6 +538,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/blur"
   react-native-geolocation-service:
     :path: "../node_modules/react-native-geolocation-service"
+  react-native-image-picker:
+    :path: "../node_modules/react-native-image-picker"
   react-native-pager-view:
     :path: "../node_modules/react-native-pager-view"
   react-native-safe-area-context:
@@ -581,8 +586,8 @@ SPEC CHECKSUMS:
   BVLinearGradient: 34a999fda29036898a09c6a6b728b0b4189e1a44
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
-  FBLazyVector: d3cdc05875c89782840d2f38e1d6174fab24e4d2
-  FBReactNativeSpec: 0612c8f2dbd774414bb778247c6ec6cb05aa4c50
+  FBLazyVector: 0507edc21c06f1650c591f0981c846445469373b
+  FBReactNativeSpec: 698ef8604615cfa7ae2119e9ca4ed7687a6ae62e
   Flipper: dbc210f7008265335b812b2a5a1122b0300e5b64
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -598,43 +603,44 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
-  RCTRequired: 1b4e0388c8ad776b2d23f8135926fa4e7ddacdf4
-  RCTTypeSafety: 23dc09d6e9ed210fabab031a568bb0194d492385
-  React: 8ca78b2619353c251478892f087d007365af8170
-  React-bridging: e98ade701d1e8e8e764a5e7a66f1725135a0a8ce
-  React-callinvoker: d32c4a1e448799506e9c45ef25ae8ff3c5f77246
-  React-Codegen: 642c7cc5e5bd43ef07f275da308d86ff05c0069c
-  React-Core: 59487b5839f3ff353bbc847df22fc7f8a42ff421
-  React-CoreModules: 62df56334be6c6ef93e1b637284abb782a731318
-  React-cxxreact: 5a641acd449213f420ec01f0c912c8433a91c4ba
-  React-hermes: 909477fce9db1d83e854489d5f3c360dd40cf8b9
-  React-jsi: 28343c93479aa1380251c450a76a9d6eabacf3cd
-  React-jsiexecutor: 47201924064085223b63ec7e3ee9fd40ad8508e8
-  React-jsinspector: 1363be638eccfe1aea1b10dd42e632b0397e5ec8
-  React-logger: 7bd569e3857d74ed412ce0a5c51f421ff7d4ca7f
+  RCTRequired: d4033a367d0bfd1f23f67b501f8cdabf9afe617e
+  RCTTypeSafety: b112b2ccc59309a65284280c0a53baf1ce4b5860
+  React: 04474547a4729eef1fb378ca42f302f4b3219eb8
+  React-bridging: 1c8695b292b4a9baaca3960f6166d9766e20492d
+  React-callinvoker: 4d91e2db7773ee3fcea2d3a5c6beb52a5bfd4d71
+  React-Codegen: 33356335c6f3b0869cb4434055fdec219139f635
+  React-Core: 634b8aa20e1dad445425ee9581f4719bcfd1b19b
+  React-CoreModules: 746825283de4b54dcb4fd88703ff516297a5f60d
+  React-cxxreact: f8d2686d98b5ffed1b1de3aa62e1f81db4903153
+  React-hermes: 4e9f5f9cfff42a23e7d6d8083e6c8a3f6f4926ee
+  React-jsi: 198b9b3e0a85e68cb6898265400fd8bf34cacda4
+  React-jsiexecutor: 53bd208e5c27939c6e6365528393445a596a9a2b
+  React-jsinspector: 26c42646ab0bb69e29e837e23754fe7121eeaf94
+  React-logger: 1bfd109a0ffa4c0989bbfac0c2d8c4abe4637faa
   react-native-blur: 3e9c8e8e9f7d17fa1b94e1a0ae9fd816675f5382
   react-native-geolocation-service: 608e1da71a1ac31b4de64d9ef2815f697978c55b
-  react-native-pager-view: e76d64a5114a152e942caa09136e4e250709378c
-  react-native-safe-area-context: dfe5aa13bee37a0c7e8059d14f72ffc076d120e9
-  React-perflogger: 48c6b363e867d64b682e84f80ca45636bd65e19c
-  React-RCTActionSheet: 33c74fe5c754835e3715c300618da9aa2f7203fa
-  React-RCTAnimation: 2dbf0120d4d1ab7716079b4180f2ca89c465e46b
-  React-RCTBlob: ccf17363f809c5030746fdb56641527e6bf9adb7
-  React-RCTImage: 88a61b23cd5a6feb8d4436f1e306d9f2ecee3462
-  React-RCTLinking: c63a07ce60a6cb7642acebc80a447fb3f1872eba
-  React-RCTNetwork: f79b6e7c64e7317d34dec7dcfabd1279a6c1d2e7
-  React-RCTSettings: 1ff0f34d41646c7942adea36ab5706320e693756
-  React-RCTText: 7cb05abb91cae0ab7841d551e811ccefa3714dbd
-  React-RCTVibration: e9164827303fb6a5cf79e4c4af4846a09956b11f
-  React-runtimeexecutor: a11d0c2e14140baf1e449264ca9168ae9ae6bbd0
-  ReactCommon: 7f86326b92009925c6dcf93f8e825060171c379f
+  react-native-image-picker: 4bc9ed38c8be255b515d8c88babbaf74973f91a8
+  react-native-pager-view: 3051346698a0ba0c4e13e40097cc11b00ee03cca
+  react-native-safe-area-context: 99b24a0c5acd0d5dcac2b1a7f18c49ea317be99a
+  React-perflogger: 6009895616a455781293950bbd63d53cfc7ffbc5
+  React-RCTActionSheet: 5e90aa5712af18bfc86c2c6d97d4dbe0e5451c1d
+  React-RCTAnimation: 50c44d6501f8bfb2fe885e544501f8798b4ff3d6
+  React-RCTBlob: 3cc08e7112dd7b77faf3fa481ba22ca2bba5f20a
+  React-RCTImage: ca8335860b5f64c383ad27f52a28d85089d49b7a
+  React-RCTLinking: 297cd91bdbf427efc861fc7943e6d683e61860fa
+  React-RCTNetwork: 8a197bff6f1dc5353484507a4cdcd47e9356316f
+  React-RCTSettings: d3db1f1e61a5ad8deb50f44f5cb6c7c3ef32b3ac
+  React-RCTText: c2c05ab3dbfb1cf5855b14802f392148970e48da
+  React-RCTVibration: 89e2cbea456ac5ec623943661d00e4dc45fe74b9
+  React-runtimeexecutor: 80065f60af4f4b05603661070c8622bb3740bf16
+  ReactCommon: 1209130f460e4aa9d255ddc75fa0a827ebf93dfb
   RNCAsyncStorage: 0c357f3156fcb16c8589ede67cc036330b6698ca
-  RNDateTimePicker: 5ff22bfec11d466a3e753046eead03cdc3b3658c
+  RNDateTimePicker: 154f8246e9c32fd663995647a7f9f667a8c6b258
   RNI18n: e2f7e76389fcc6e84f2c8733ea89b92502351fd8
-  RNScreens: 0df01424e9e0ed7827200d6ed1087ddd06c493f9
-  RNSVG: 07037623c36f12e41312730622d5f6b3656227ca
+  RNScreens: 1b7bb502dac62cc4cf01b94bea591c8da275132f
+  RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: 6c8252e38d65aa387daee699eacf027e055e0b31
+  Yoga: 043f8eb97345d0171f27fead4d1849cacf0472a5
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 53cb586e961c9b660218faaf010809cecf2c9d67

--- a/clients/app/package.json
+++ b/clients/app/package.json
@@ -30,6 +30,7 @@
     "react-native": "^0.70.1",
     "react-native-geolocation-service": "^5.3.0",
     "react-native-i18n": "^2.0.15",
+    "react-native-image-picker": "^4.10.0",
     "react-native-linear-gradient": "^2.6.2",
     "react-native-pager-view": "^6.0.0",
     "react-native-safe-area-context": "^4.3.4",

--- a/clients/app/src/views/components/base/RemoveButton/index.ts
+++ b/clients/app/src/views/components/base/RemoveButton/index.ts
@@ -1,1 +1,2 @@
 export { default as RemoveButton } from './RemoveButton';
+export { ORIGINAL_SIZE } from './buildSvg';

--- a/clients/app/src/views/components/compositions/AttacheImage/AttacheImage.tsx
+++ b/clients/app/src/views/components/compositions/AttacheImage/AttacheImage.tsx
@@ -1,18 +1,82 @@
+import { generateToken } from '@ultras/utils';
 import React from 'react';
-import { Box, Center, Text } from 'native-base';
-import I18n from 'i18n/i18n';
+import { Box, Text } from 'native-base';
 import { useTheme } from 'themes';
-import { IAttacheImageProps } from './types';
+import ImagePreview from './components/ImagePreview';
+import { IAttacheImageProps, IImageItem, ImageType } from './types';
+import TapToAdd from './components/TapToAdd';
 
-const AttacheImage: React.FC<IAttacheImageProps> = ({ title }) => {
+const AttacheImage: React.FC<IAttacheImageProps> = ({
+  title,
+  rounded = false,
+  multiple = false,
+}) => {
+  const [images, setImages] = React.useState<Array<IImageItem>>([]);
   const { colors } = useTheme();
+
+  const appendEmptyItem = React.useCallback(() => {
+    const emptyItem: IImageItem = {
+      id: 'id' + generateToken(10),
+      image: null,
+    };
+
+    setImages(oldImages => [...oldImages, emptyItem]);
+  }, []);
+
+  const onRemove = React.useCallback((id: string) => {
+    setImages(oldImages => oldImages.filter(image => id !== image.id));
+  }, []);
+
+  const onChoose = React.useCallback((id: string, image: ImageType) => {
+    setImages(oldImages =>
+      oldImages.map(imageItem => {
+        if (imageItem.id === id) {
+          imageItem.image = image;
+        }
+
+        return imageItem;
+      })
+    );
+  }, []);
+
+  React.useEffect(() => {
+    if (images.length === 0) {
+      return appendEmptyItem();
+    }
+
+    if (!multiple) {
+      return;
+    }
+
+    const lastOne = images[images.length - 1];
+    if (lastOne.image) {
+      appendEmptyItem();
+    }
+  }, [appendEmptyItem, images, multiple]);
 
   return (
     <Box bg={colors.backgroundInput} p={'4'} rounded={'xl'}>
       <Text variant={'smallText'}>{title}</Text>
-      <Center bg={colors.buttonSecondaryDisabled} mt={'3'} rounded={'md'} h={'40'}>
-        <Text variant={'smallText'}>{I18n.t('common-tapToAdd')}</Text>
-      </Center>
+
+      <Box flexDirection="row" flexWrap="wrap" marginTop="2">
+        {images.map(imageItem => (
+          <Box
+            key={imageItem.id}
+            backgroundColor={colors.buttonSecondaryDisabled}
+            rounded={rounded ? 'full' : 'md'}
+            height={rounded ? 100 : '40'}
+            width={rounded ? 100 : 'full'}
+            margin="1"
+            position="relative"
+          >
+            {imageItem.image ? (
+              <ImagePreview imageItem={imageItem} rounded={rounded} onRemove={onRemove} />
+            ) : (
+              <TapToAdd imageItem={imageItem} onChoose={onChoose} />
+            )}
+          </Box>
+        ))}
+      </Box>
     </Box>
   );
 };

--- a/clients/app/src/views/components/compositions/AttacheImage/AttacheImage.tsx
+++ b/clients/app/src/views/components/compositions/AttacheImage/AttacheImage.tsx
@@ -3,16 +3,31 @@ import React from 'react';
 import { Box, Text } from 'native-base';
 import { useTheme } from 'themes';
 import ImagePreview from './components/ImagePreview';
-import { IAttacheImageProps, IImageItem, ImageType } from './types';
+import { IAttacheImageProps, IImageItem, ImageType, ISize } from './types';
 import TapToAdd from './components/TapToAdd';
 
 const AttacheImage: React.FC<IAttacheImageProps> = ({
   title,
+  size = null,
   rounded = false,
   multiple = false,
 }) => {
   const [images, setImages] = React.useState<Array<IImageItem>>([]);
   const { colors } = useTheme();
+
+  const computedSize = React.useMemo((): ISize => {
+    if (rounded) {
+      return {
+        height: size || 100,
+        width: size || 100,
+      };
+    }
+
+    return {
+      width: size ? 100 : 'full',
+      height: size || 40,
+    };
+  }, [size, rounded]);
 
   const appendEmptyItem = React.useCallback(() => {
     const emptyItem: IImageItem = {
@@ -64,13 +79,18 @@ const AttacheImage: React.FC<IAttacheImageProps> = ({
             key={imageItem.id}
             backgroundColor={colors.buttonSecondaryDisabled}
             rounded={rounded ? 'full' : 'md'}
-            height={rounded ? 100 : '40'}
-            width={rounded ? 100 : 'full'}
+            height={computedSize.height}
+            width={computedSize.width}
             margin="1"
             position="relative"
           >
             {imageItem.image ? (
-              <ImagePreview imageItem={imageItem} rounded={rounded} onRemove={onRemove} />
+              <ImagePreview
+                computedSize={computedSize}
+                imageItem={imageItem}
+                rounded={rounded}
+                onRemove={onRemove}
+              />
             ) : (
               <TapToAdd imageItem={imageItem} onChoose={onChoose} />
             )}

--- a/clients/app/src/views/components/compositions/AttacheImage/components/ImagePreview.tsx
+++ b/clients/app/src/views/components/compositions/AttacheImage/components/ImagePreview.tsx
@@ -1,6 +1,8 @@
 import { Box } from 'native-base';
+import { SizeType } from 'native-base/lib/typescript/components/types';
 import React from 'react';
 import { Image, View, StyleSheet, ImageSourcePropType } from 'react-native';
+import { useTheme } from 'themes';
 import {
   ORIGINAL_SIZE as removeButtonSize,
   RemoveButton,
@@ -8,15 +10,41 @@ import {
 import { offsetForRectangle, offsetForRounded } from '../helpers';
 import { IImagePreviewProps } from '../types';
 
-const ImagePreview: React.FC<IImagePreviewProps> = ({ imageItem, rounded, onRemove }) => {
+const ImagePreview: React.FC<IImagePreviewProps> = ({
+  imageItem,
+  rounded,
+  computedSize,
+  onRemove,
+}) => {
+  const { theming } = useTheme();
+
+  const containerStyle = React.useMemo(() => {
+    let offset = 0;
+
+    if (!rounded) {
+      offset = offsetForRectangle(removeButtonSize);
+    } else {
+      let size = 0;
+      if (typeof computedSize.height === 'number') {
+        size = computedSize.height;
+      } else {
+        if (computedSize.height) {
+          size = theming.sizes[computedSize.height];
+        }
+      }
+
+      offset = offsetForRounded(removeButtonSize, size);
+    }
+
+    return {
+      right: offset,
+      top: offset,
+    };
+  }, [rounded, computedSize.height, theming.sizes]);
+
   return (
     <>
-      <View
-        style={[
-          styles.container,
-          !rounded ? styles.containerRectangle : styles.containerRounded,
-        ]}
-      >
+      <View style={[styles.container, containerStyle]}>
         <RemoveButton onPress={() => onRemove(imageItem.id)} />
       </View>
 
@@ -31,16 +59,6 @@ const styles = StyleSheet.create({
   container: {
     position: 'absolute',
     zIndex: 2,
-  },
-
-  containerRounded: {
-    top: offsetForRounded(removeButtonSize, 100),
-    right: offsetForRounded(removeButtonSize, 100),
-  },
-
-  containerRectangle: {
-    top: offsetForRectangle(removeButtonSize),
-    right: offsetForRectangle(removeButtonSize),
   },
 
   image: {

--- a/clients/app/src/views/components/compositions/AttacheImage/components/ImagePreview.tsx
+++ b/clients/app/src/views/components/compositions/AttacheImage/components/ImagePreview.tsx
@@ -1,0 +1,53 @@
+import { Box } from 'native-base';
+import React from 'react';
+import { Image, View, StyleSheet, ImageSourcePropType } from 'react-native';
+import {
+  ORIGINAL_SIZE as removeButtonSize,
+  RemoveButton,
+} from 'views/components/base/RemoveButton';
+import { offsetForRectangle, offsetForRounded } from '../helpers';
+import { IImagePreviewProps } from '../types';
+
+const ImagePreview: React.FC<IImagePreviewProps> = ({ imageItem, rounded, onRemove }) => {
+  return (
+    <>
+      <View
+        style={[
+          styles.container,
+          !rounded ? styles.containerRectangle : styles.containerRounded,
+        ]}
+      >
+        <RemoveButton onPress={() => onRemove(imageItem.id)} />
+      </View>
+
+      <Box height="full" width="full" overflow="hidden" rounded={rounded ? 'full' : 'md'}>
+        <Image source={imageItem.image as ImageSourcePropType} style={styles.image} />
+      </Box>
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    zIndex: 2,
+  },
+
+  containerRounded: {
+    top: offsetForRounded(removeButtonSize, 100),
+    right: offsetForRounded(removeButtonSize, 100),
+  },
+
+  containerRectangle: {
+    top: offsetForRectangle(removeButtonSize),
+    right: offsetForRectangle(removeButtonSize),
+  },
+
+  image: {
+    height: '100%',
+    width: '100%',
+    resizeMode: 'cover',
+  },
+});
+
+export default ImagePreview;

--- a/clients/app/src/views/components/compositions/AttacheImage/components/TapToAdd.tsx
+++ b/clients/app/src/views/components/compositions/AttacheImage/components/TapToAdd.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { launchImageLibrary } from 'react-native-image-picker';
+import { Pressable, Text } from 'native-base';
+import I18n from 'i18n/i18n';
+import { ITapToAddProps } from '../types';
+
+const TapToAdd: React.FC<ITapToAddProps> = ({ imageItem, onChoose }) => {
+  const onChoosePress = React.useCallback(async () => {
+    // we also can use <<launchCamera>> function instead,
+    // but need to ask camera permission first.
+    const response = await launchImageLibrary({
+      presentationStyle: 'fullScreen',
+      mediaType: 'photo',
+      selectionLimit: 1,
+    });
+
+    if (!response.assets) {
+      return;
+    }
+
+    const chosen = response.assets[0];
+    onChoose(imageItem.id, chosen);
+  }, [imageItem, onChoose]);
+
+  return (
+    <Pressable
+      height="full"
+      width="full"
+      justifyContent="center"
+      alignItems="center"
+      onPress={onChoosePress}
+    >
+      <Text variant={'smallText'} textAlign="center">
+        {I18n.t('common-tapToAdd')}
+      </Text>
+    </Pressable>
+  );
+};
+
+export default TapToAdd;

--- a/clients/app/src/views/components/compositions/AttacheImage/helpers.ts
+++ b/clients/app/src/views/components/compositions/AttacheImage/helpers.ts
@@ -1,0 +1,8 @@
+export function offsetForRectangle(buttonSize: number): number {
+  return (-1 * buttonSize) / 4.4;
+}
+
+export function offsetForRounded(buttonSize: number, circleSize: number) {
+  const sinIn45 = Math.sin((45 * Math.PI) / 180);
+  return ((1 - sinIn45) * circleSize) / 2 - buttonSize / 2;
+}

--- a/clients/app/src/views/components/compositions/AttacheImage/types.ts
+++ b/clients/app/src/views/components/compositions/AttacheImage/types.ts
@@ -1,3 +1,4 @@
+import { SizeType } from 'native-base/lib/typescript/components/types';
 import type { Asset } from 'react-native-image-picker';
 
 export type ImageType = Asset;
@@ -7,15 +8,21 @@ export interface IImageItem {
   image: null | ImageType;
 }
 
+export interface ISize {
+  width: number | SizeType;
+  height: number | SizeType;
+}
+
 export interface IAttacheImageProps {
   title: string;
   multiple?: boolean;
   rounded?: boolean;
-
+  size?: null | number | SizeType;
   onRemovePress?(): void;
 }
 
 export interface IImagePreviewProps {
+  computedSize: ISize;
   imageItem: IImageItem;
   rounded: boolean;
   onRemove(id: string): void;

--- a/clients/app/src/views/components/compositions/AttacheImage/types.ts
+++ b/clients/app/src/views/components/compositions/AttacheImage/types.ts
@@ -1,3 +1,27 @@
+import type { Asset } from 'react-native-image-picker';
+
+export type ImageType = Asset;
+
+export interface IImageItem {
+  id: string;
+  image: null | ImageType;
+}
+
 export interface IAttacheImageProps {
   title: string;
+  multiple?: boolean;
+  rounded?: boolean;
+
+  onRemovePress?(): void;
+}
+
+export interface IImagePreviewProps {
+  imageItem: IImageItem;
+  rounded: boolean;
+  onRemove(id: string): void;
+}
+
+export interface ITapToAddProps {
+  imageItem: IImageItem;
+  onChoose(id: string, image: ImageType): void;
 }

--- a/clients/app/src/views/screens/CreateFanClub/screens/CreateFanClub/containers/VisualContainer.tsx
+++ b/clients/app/src/views/screens/CreateFanClub/screens/CreateFanClub/containers/VisualContainer.tsx
@@ -1,24 +1,16 @@
 import React from 'react';
 import { Text, VStack } from 'native-base';
 import I18n from 'i18n/i18n';
-import { InputSection } from 'views/components/base/InputSection';
+import AttacheImage from 'views/components/compositions/AttacheImage';
 
 const VisualContainer: React.FC = () => {
   return (
     <VStack space={4} paddingX={3}>
       <Text variant="cardInfo">{I18n.t('fanClubs-add-visuals')}</Text>
 
-      <InputSection padding={3}>
-        <Text>{I18n.t('fanClubs-add-visuals-avatar')}</Text>
+      <AttacheImage title={I18n.t('fanClubs-add-visuals-avatar')} rounded={true} />
 
-        {/* @TODO: add avatar component here */}
-      </InputSection>
-
-      <InputSection padding={3}>
-        <Text>{I18n.t('fanClubs-add-visuals-cover')}</Text>
-
-        {/* @TODO: add cover photo component here */}
-      </InputSection>
+      <AttacheImage title={I18n.t('fanClubs-add-visuals-cover')} />
     </VStack>
   );
 };


### PR DESCRIPTION
#### Completed logic of `AttachImage` component.

---

Component separated into files:

- `AttachImage` - the container component
- `ImagePreview` - the component which is responsible for:
  - rendering chosen image
  - remove the selected image
- `TapToAdd` - the component which is designed for choosing images from the library _(we also can run the camera, but it's not implemented yet)_

---

Components have the ability to:
- render two ways (rounded, rectangle)
- choose multiple images

---

#### for `RemoveButton` position in rounded component we need to calculate offset using `sin` or `cos` in 45deg.
