### PR TITLE
[fix] android keyboard automatic close fixed

### DIFF
--- a/clients/app/android/build.gradle
+++ b/clients/app/android/build.gradle
@@ -4,11 +4,13 @@ buildscript {
     ext {
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 30
+        compileSdkVersion = 32
         targetSdkVersion = 30
         ndkVersion = "20.1.5948944"
 
         playServicesLocationVersion = "17.0.0"
+
+        kotlin_version = "1.7.0"
     }
     repositories {
         google()
@@ -16,6 +18,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.2.1")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/clients/app/ios/Podfile.lock
+++ b/clients/app/ios/Podfile.lock
@@ -385,11 +385,11 @@ PODS:
     - React-perflogger (= 0.70.3)
   - RNCAsyncStorage (1.17.10):
     - React-Core
-  - RNDateTimePicker (6.5.0):
+  - RNDateTimePicker (6.5.2):
     - React-Core
   - RNI18n (2.0.15):
     - React
-  - RNScreens (3.18.1):
+  - RNScreens (3.10.2):
     - React-Core
     - React-RCTImage
   - RNSVG (13.4.0):
@@ -635,9 +635,9 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: e9b1f9310158a1e265bcdfdfd8c62d6174b947a2
   ReactCommon: 01064177e66d652192c661de899b1076da962fd9
   RNCAsyncStorage: 0c357f3156fcb16c8589ede67cc036330b6698ca
-  RNDateTimePicker: 154f8246e9c32fd663995647a7f9f667a8c6b258
+  RNDateTimePicker: 3f32aa2247836c12618d346113e5e82ea60ddd9c
   RNI18n: e2f7e76389fcc6e84f2c8733ea89b92502351fd8
-  RNScreens: 1b7bb502dac62cc4cf01b94bea591c8da275132f
+  RNScreens: d6da2b9e29cf523832c2542f47bf1287318b1868
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 2ed968a4f060a92834227c036279f2736de0fce3

--- a/clients/app/package.json
+++ b/clients/app/package.json
@@ -34,7 +34,7 @@
     "react-native-linear-gradient": "^2.6.2",
     "react-native-pager-view": "^6.0.0",
     "react-native-safe-area-context": "^4.3.4",
-    "react-native-screens": "^3.17.0",
+    "react-native-screens": "3.10.2",
     "react-native-svg": "^13.2.0",
     "react-native-swiper": "^1.6.0",
     "react-native-tab-view": "^3.1.1",

--- a/clients/app/src/views/screens/JoinUs/components/JoinUsComponent.tsx
+++ b/clients/app/src/views/screens/JoinUs/components/JoinUsComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, ListRenderItem } from 'react-native';
+import { StyleSheet, ListRenderItem, Platform } from 'react-native';
 import { Box, FlatList } from 'native-base';
 import { useRoute } from '@react-navigation/native';
 import useNavigationWithParams from 'utils/hooks/useNavigationWithParams';
@@ -68,7 +68,7 @@ const JoinUsComponent: React.FC<IJoinUsComponentProps> = ({
 
   React.useEffect(() => {
     if (keyboardHeight !== 0) {
-      setTimeout(() => flatListRef?.current?.scrollToEnd());
+      setTimeout(() => flatListRef?.current?.scrollToEnd(), animation_delay);
     }
   }, [keyboardHeight]);
 
@@ -217,6 +217,14 @@ const JoinUsComponent: React.FC<IJoinUsComponentProps> = ({
     [getRightMessageOptions, renderRightComponent, step, useStore]
   );
 
+  const bottomSpace = React.useMemo(() => {
+    if (Platform.OS === 'android') {
+      return 0;
+    }
+
+    return keyboardHeight || 0;
+  }, [keyboardHeight]);
+
   return (
     <FlatList
       ref={flatListRef}
@@ -225,8 +233,9 @@ const JoinUsComponent: React.FC<IJoinUsComponentProps> = ({
       keyExtractor={item => item.key}
       showsVerticalScrollIndicator={false}
       contentContainerStyle={styles.contentContainerStyle}
-      style={{ marginBottom: +keyboardHeight }}
+      style={{ marginBottom: bottomSpace }}
       keyboardShouldPersistTaps={'always'}
+      removeClippedSubviews={false}
     />
   );
 };


### PR DESCRIPTION
#### This PR includes:

---

- Make the Android app workable:
  - Update android Minimum SDK Compiler version
  - Specify Kotlin version for dependencies.
- Don't close Android keyboard on `TextInput` focus.

---

__Closing of keyboard on Android is caused automatically if `TextInput` is inside of `FlatList`, solution for this need to add `removeClippedSubviews={false}` prop on `FlatList`.__