### PR TITLE
[feat] Edit user profile screen.

### DIFF
--- a/clients/app/src/i18n/locales/en.ts
+++ b/clients/app/src/i18n/locales/en.ts
@@ -25,6 +25,7 @@ export default {
   'common-create': 'Create',
   'common-tapToAdd': 'Tap to Add',
   'common-next': 'Next',
+  'common-save': 'Save',
 
   // splash
   'splash-slogan': '#WatchFootball',
@@ -181,4 +182,10 @@ export default {
   'profile-edit': 'Edit Profile',
   'profile-logout': 'Log out',
   'profile-logoutOfX': 'Log out of {{x}}?',
+  'profile-edit-tapToEdit': 'Tap to Edit',
+  'profile-edit-fullName': 'Full Name',
+  'profile-edit-phoneNumber': 'Phone Number',
+  'profile-edit-email': 'Email',
+  'profile-edit-description':
+    'Tap to change Full Name, Email and Phone Number. Note, that Email/Phone Number change will need confirmation.',
 };

--- a/clients/app/src/views/components/base/KeyValue/KeyValue.tsx
+++ b/clients/app/src/views/components/base/KeyValue/KeyValue.tsx
@@ -5,6 +5,7 @@ import { KeyValueInner } from './KeyValueInner';
 import { IKeyValueProps } from './types';
 
 const KeyValue: React.FC<IKeyValueProps> = ({
+  viewMode = 'inline',
   name,
   value,
   description,
@@ -14,7 +15,13 @@ const KeyValue: React.FC<IKeyValueProps> = ({
   return (
     <VStack>
       <InputSection>
-        <KeyValueInner name={name} value={value} options={options} onChange={onChange} />
+        <KeyValueInner
+          viewMode={viewMode}
+          name={name}
+          value={value}
+          options={options}
+          onChange={onChange}
+        />
       </InputSection>
 
       {description && (

--- a/clients/app/src/views/components/base/KeyValue/KeyValueInner.tsx
+++ b/clients/app/src/views/components/base/KeyValue/KeyValueInner.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { HStack, Text, Switch } from 'native-base';
+import { HStack, VStack, Text, Switch } from 'native-base';
 import { useTheme } from 'themes';
 import KeyValueDropdown from './KeyValueDropdown';
 import { IKeyValueProps } from './types';
 
 export const KeyValueInner: React.FC<IKeyValueProps> = ({
+  viewMode = 'inline',
   name,
   value,
   options,
@@ -47,10 +48,48 @@ export const KeyValueInner: React.FC<IKeyValueProps> = ({
     rightComponent = value;
   }
 
+  const textVariant = React.useMemo(() => {
+    return viewMode === 'inline' ? 'messageInvert' : 'cardTime';
+  }, [viewMode]);
+
+  const textProps = React.useMemo(() => {
+    if (viewMode === 'inline') {
+      return {};
+    } else {
+      return {
+        marginBottom: 1,
+      };
+    }
+  }, [viewMode]);
+
+  const GroupComponent = React.useMemo(() => {
+    return viewMode === 'inline' ? HStack : VStack;
+  }, [viewMode]);
+
+  const groupProps = React.useMemo(() => {
+    if (viewMode === 'inline') {
+      return {
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingY: '2',
+        paddingX: '3',
+      };
+    } else {
+      return {
+        alignItems: 'flex-start',
+        paddingY: '2',
+        paddingX: '3',
+      };
+    }
+  }, [viewMode]);
+
   return (
-    <HStack justifyContent={'space-between'} alignItems={'center'} p={'3'}>
-      <Text variant={'messageInvert'}>{name}</Text>
+    <GroupComponent {...groupProps}>
+      <Text variant={textVariant} {...textProps}>
+        {name}
+      </Text>
+
       {rightComponent}
-    </HStack>
+    </GroupComponent>
   );
 };

--- a/clients/app/src/views/components/base/KeyValue/types.ts
+++ b/clients/app/src/views/components/base/KeyValue/types.ts
@@ -1,6 +1,7 @@
 type TValue = string | boolean | React.ReactNode;
 
 export interface IKeyValueProps<T extends TValue = TValue> {
+  viewMode?: 'inline' | 'label';
   name: string;
   options?: Record<string, string>;
   value: T;

--- a/clients/app/src/views/components/compositions/AttacheImage/AttacheImage.tsx
+++ b/clients/app/src/views/components/compositions/AttacheImage/AttacheImage.tsx
@@ -8,11 +8,21 @@ import TapToAdd from './components/TapToAdd';
 
 const AttacheImage: React.FC<IAttacheImageProps> = ({
   title,
+  insideOfInputSection = true,
+  initialImages = [],
   size = null,
   rounded = false,
+  centered = false,
   multiple = false,
+  removable = true,
 }) => {
-  const [images, setImages] = React.useState<Array<IImageItem>>([]);
+  const [images, setImages] = React.useState<Array<IImageItem>>(
+    initialImages.map((image: ImageType) => ({
+      id: 'id' + generateToken(10),
+      image: image,
+    }))
+  );
+
   const { colors } = useTheme();
 
   const computedSize = React.useMemo((): ISize => {
@@ -70,8 +80,13 @@ const AttacheImage: React.FC<IAttacheImageProps> = ({
   }, [appendEmptyItem, images, multiple]);
 
   return (
-    <Box bg={colors.backgroundInput} p={'4'} rounded={'xl'}>
-      <Text variant={'smallText'}>{title}</Text>
+    <Box
+      backgroundColor={insideOfInputSection ? colors.backgroundInput : colors.transparent}
+      padding={insideOfInputSection ? 4 : 0}
+      rounded={insideOfInputSection ? 'xl' : 0}
+      alignItems={centered ? 'center' : 'flex-start'}
+    >
+      {title && <Text variant={'smallText'}>{title}</Text>}
 
       <Box flexDirection="row" flexWrap="wrap" marginTop="2">
         {images.map(imageItem => (
@@ -89,6 +104,7 @@ const AttacheImage: React.FC<IAttacheImageProps> = ({
                 computedSize={computedSize}
                 imageItem={imageItem}
                 rounded={rounded}
+                removable={removable}
                 onRemove={onRemove}
               />
             ) : (

--- a/clients/app/src/views/components/compositions/AttacheImage/components/ImagePreview.tsx
+++ b/clients/app/src/views/components/compositions/AttacheImage/components/ImagePreview.tsx
@@ -1,5 +1,4 @@
 import { Box } from 'native-base';
-import { SizeType } from 'native-base/lib/typescript/components/types';
 import React from 'react';
 import { Image, View, StyleSheet, ImageSourcePropType } from 'react-native';
 import { useTheme } from 'themes';
@@ -14,6 +13,7 @@ const ImagePreview: React.FC<IImagePreviewProps> = ({
   imageItem,
   rounded,
   computedSize,
+  removable,
   onRemove,
 }) => {
   const { theming } = useTheme();
@@ -44,9 +44,11 @@ const ImagePreview: React.FC<IImagePreviewProps> = ({
 
   return (
     <>
-      <View style={[styles.container, containerStyle]}>
-        <RemoveButton onPress={() => onRemove(imageItem.id)} />
-      </View>
+      {removable && (
+        <View style={[styles.container, containerStyle]}>
+          <RemoveButton onPress={() => onRemove(imageItem.id)} />
+        </View>
+      )}
 
       <Box height="full" width="full" overflow="hidden" rounded={rounded ? 'full' : 'md'}>
         <Image source={imageItem.image as ImageSourcePropType} style={styles.image} />

--- a/clients/app/src/views/components/compositions/AttacheImage/types.ts
+++ b/clients/app/src/views/components/compositions/AttacheImage/types.ts
@@ -14,10 +14,14 @@ export interface ISize {
 }
 
 export interface IAttacheImageProps {
-  title: string;
+  insideOfInputSection: boolean;
+  title?: string;
   multiple?: boolean;
   rounded?: boolean;
+  centered?: boolean;
   size?: null | number | SizeType;
+  initialImages?: Array<ImageType>;
+  removable?: boolean;
   onRemovePress?(): void;
 }
 
@@ -25,6 +29,7 @@ export interface IImagePreviewProps {
   computedSize: ISize;
   imageItem: IImageItem;
   rounded: boolean;
+  removable: boolean;
   onRemove(id: string): void;
 }
 

--- a/clients/app/src/views/screens/EditProfile/EditProfile.tsx
+++ b/clients/app/src/views/screens/EditProfile/EditProfile.tsx
@@ -1,11 +1,52 @@
 import React from 'react';
-import { Text } from 'native-base';
+import { Button } from 'native-base';
+import { useTheme } from 'themes';
+import I18n from 'i18n/i18n';
+import useNavigationWithParams from 'utils/hooks/useNavigationWithParams';
+import EditAvatarContainer from './containers/EditAvatarContainer';
+import PersonalInfoContainer from './containers/PersonalInfoContainer';
+import buildUserStore from 'stores/user';
+import { Loader } from 'views/components/base/ListComponents';
+import authenticationStore, { IState } from 'stores/authentication';
+
+const useAuthenticationStore = authenticationStore.initStore();
 
 const EditProfile: React.FC = () => {
+  const me = useAuthenticationStore((state: IState) => state.user);
+
+  const userStore = React.useMemo(() => buildUserStore(), []);
+  const { single: storeSingle } = userStore.useSelector('single');
+
+  React.useEffect(() => {
+    storeSingle.getSingle(me.id!);
+  }, [me?.id, storeSingle]);
+
+  const { colors } = useTheme();
+  const { goBack } = useNavigationWithParams();
+
   return (
-    <Text variant={'title'} p={'4'}>
-      EditProfile Content...
-    </Text>
+    <>
+      <Button
+        onPress={goBack}
+        variant={'empty'}
+        alignSelf="flex-start"
+        _text={{ color: colors.textAction }}
+        mt={'5'}
+        mb={'2.5'}
+        px={'2.5'}
+      >
+        {I18n.t('common-close')}
+      </Button>
+
+      {storeSingle.status === 'loading' ? (
+        <Loader />
+      ) : (
+        <>
+          <EditAvatarContainer data={storeSingle.data!} />
+          <PersonalInfoContainer data={storeSingle.data!} />
+        </>
+      )}
+    </>
   );
 };
 

--- a/clients/app/src/views/screens/EditProfile/components/EditAvatarComponent.tsx
+++ b/clients/app/src/views/screens/EditProfile/components/EditAvatarComponent.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Center, Text } from 'native-base';
+import I18n from 'i18n/i18n';
+import AttacheImage from 'views/components/compositions/AttacheImage';
+import { IEditAvatarComponentProps } from './types';
+
+const EditAvatarComponent: React.FC<IEditAvatarComponentProps> = ({
+  avatar,
+  onChange,
+}) => {
+  return (
+    <>
+      <AttacheImage
+        insideOfInputSection={false}
+        centered={true}
+        rounded={true}
+        size={136}
+        multiple={false}
+        removable={false}
+        initialImages={avatar ? [{ uri: avatar }] : []}
+      />
+
+      <Center marginTop={2}>
+        <Text variant="cardTime">{I18n.t('profile-edit-tapToEdit')}</Text>
+      </Center>
+    </>
+  );
+};
+
+export default EditAvatarComponent;

--- a/clients/app/src/views/screens/EditProfile/components/PersonalInfoInputComponent.tsx
+++ b/clients/app/src/views/screens/EditProfile/components/PersonalInfoInputComponent.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Input } from 'native-base';
+import { useTheme } from 'themes';
+import { KeyValueInner } from 'views/components/base/KeyValue';
+import { IPersonalInfoInputComponentProps } from './types';
+
+const PersonalInfoInputComponent: React.FC<IPersonalInfoInputComponentProps> = ({
+  name,
+  value,
+  onChange,
+}) => {
+  const { colors } = useTheme();
+
+  return (
+    <KeyValueInner
+      viewMode="label"
+      name={name}
+      value={
+        <Input
+          backgroundColor={colors.transparent}
+          padding={0}
+          fontSize="4xl"
+          value={value || ''}
+          onChange={onChange}
+          clearButtonMode="never"
+        />
+      }
+    />
+  );
+};
+
+export default PersonalInfoInputComponent;

--- a/clients/app/src/views/screens/EditProfile/components/types.ts
+++ b/clients/app/src/views/screens/EditProfile/components/types.ts
@@ -1,0 +1,12 @@
+import { NativeSyntheticEvent, TextInputChangeEventData } from 'react-native';
+
+export interface IEditAvatarComponentProps {
+  avatar: Nullable<string>;
+  onChange?(image: string): void;
+}
+
+export interface IPersonalInfoInputComponentProps {
+  name: string;
+  value?: Nullable<string>;
+  onChange?(e: NativeSyntheticEvent<TextInputChangeEventData>): void;
+}

--- a/clients/app/src/views/screens/EditProfile/containers/EditAvatarContainer.tsx
+++ b/clients/app/src/views/screens/EditProfile/containers/EditAvatarContainer.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Box, Center, Text } from 'native-base';
+import { IEditAvatarContainerProps } from './types';
+import EditAvatarComponent from '../components/EditAvatarComponent';
+
+const EditAvatarContainer: React.FC<IEditAvatarContainerProps> = ({ data }) => {
+  return (
+    <Box padding={2}>
+      <EditAvatarComponent avatar={data.avatar} />
+
+      <Center marginTop={5}>
+        <Text variant={'sectionTitle'}>{data.username}</Text>
+      </Center>
+    </Box>
+  );
+};
+
+export default EditAvatarContainer;

--- a/clients/app/src/views/screens/EditProfile/containers/PersonalInfoContainer.tsx
+++ b/clients/app/src/views/screens/EditProfile/containers/PersonalInfoContainer.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Box, Button } from 'native-base';
+import I18n from 'i18n/i18n';
+import { KeyValueGroup } from 'views/components/base/KeyValue';
+import PersonalInfoInputComponent from '../components/PersonalInfoInputComponent';
+import { IPersonalInfoContainerProps } from './types';
+
+const PersonalInfoContainer: React.FC<IPersonalInfoContainerProps> = ({ data }) => {
+  return (
+    <Box padding={4}>
+      <KeyValueGroup description={I18n.t('profile-edit-description')}>
+        <PersonalInfoInputComponent
+          name={I18n.t('profile-edit-fullName')}
+          value={data.fullname}
+        />
+
+        <PersonalInfoInputComponent
+          name={I18n.t('profile-edit-phoneNumber')}
+          value={data.phone}
+        />
+
+        <PersonalInfoInputComponent
+          name={I18n.t('profile-edit-email')}
+          value={data.email}
+        />
+      </KeyValueGroup>
+
+      <Button variant="primary" marginTop="8">{I18n.t('common-save')}</Button>
+    </Box>
+  );
+};
+
+export default PersonalInfoContainer;

--- a/clients/app/src/views/screens/EditProfile/containers/types.ts
+++ b/clients/app/src/views/screens/EditProfile/containers/types.ts
@@ -1,0 +1,9 @@
+import { UserViewModel } from '@ultras/view-models';
+
+export interface IEditAvatarContainerProps {
+  data: UserViewModel;
+}
+
+export interface IPersonalInfoContainerProps {
+  data: UserViewModel;
+}


### PR DESCRIPTION
#### This PR includes:

---

- The `EditProfile` screen UI is completed.
- Added two props for `AttachImage` component:
  -  `removable` - means the user can remove the image (default: true).
  - `initialImages` - the initial images list (default: empty array).
- `KeyValueInner` component has two variants of the label:
  - `inline` - text and components are aligned horizontally.
  - `label` - text and component are aligned vertically, and the text has a smaller font.