### PR TITLE
[feat] Update user profile with confirmation.

### DIFF
--- a/apis/core-api/src/api/routes/v1/users/ControllerAdapter.ts
+++ b/apis/core-api/src/api/routes/v1/users/ControllerAdapter.ts
@@ -191,6 +191,29 @@ class ControllerAdapter {
 
     return ctx.ok(response);
   }
+
+  static async updateProfile(ctx: Context): Promise<void> {
+    /** VALIDATIONS, PARAMETERS */
+    const { userId } = ctx.user;
+    const { code, phone, email, fullname } = ctx.request.body;
+
+    /** CONTROLLERS */
+    const { data } = await UserController.updateProfile({
+      userId,
+      code,
+      phone,
+      email,
+      fullname,
+    });
+
+    /** RESPONSE */
+    // @TODO make response types
+    const response = {
+      data,
+    };
+
+    return ctx.ok(response);
+  }
 }
 
 export default ControllerAdapter;

--- a/apis/core-api/src/api/routes/v1/users/index.ts
+++ b/apis/core-api/src/api/routes/v1/users/index.ts
@@ -28,6 +28,7 @@ router.delete(
 );
 
 router.get('/me', parseAuthToken(), checkUserAuth(), ControllerAdapter.getMe);
+router.put('/me', parseAuthToken(), checkUserAuth(), ControllerAdapter.updateProfile);
 router.get('/profile/:id', ControllerAdapter.getProfile);
 
 export default router;

--- a/apis/core-api/src/core/controllers/UserController/UserController.ts
+++ b/apis/core-api/src/core/controllers/UserController/UserController.ts
@@ -1,4 +1,5 @@
 import { NotifiedProviderEnum, UserErrorEnum } from '@ultras/utils';
+import { Transaction } from 'sequelize';
 import BaseController from 'core/controllers/BaseController';
 import {
   AuthenticationError,
@@ -19,7 +20,6 @@ import {
 } from 'core/services';
 
 import {
-  AuthTokenType,
   UserCheckUsernameParams,
   UserCheckUsernameResult,
   UserConfirmIdentityParams,
@@ -39,6 +39,11 @@ import {
   ProfileParams,
   ProfileResult,
   UserAndTeams,
+  UpdateProfileParams,
+  UpdateProfileResult,
+  UpdateProfileStatusType,
+  UpdateProfileFieldResult,
+  UpdateProfileFieldParams,
 } from './types';
 
 class UserController extends BaseController {
@@ -384,6 +389,75 @@ class UserController extends BaseController {
   }
 
   /**
+   * Update user's profile.
+   */
+  static async updateProfile({
+    userId,
+    code,
+    phone,
+    email,
+    fullname,
+  }: UpdateProfileParams): UpdateProfileResult {
+    const status: UpdateProfileStatusType = await this.withTransaction(
+      async (transaction): Promise<UpdateProfileStatusType> => {
+        // update user's email address
+        if (email) {
+          const { actionStatus, codeGenerated } =
+            await this.updateProfileConfirmableField(
+              {
+                field: 'email',
+                value: email,
+                provider: NotifiedProviderEnum.email,
+                code,
+              },
+              transaction
+            );
+
+          if (actionStatus === 'updated') {
+            await UserService.updateEmail({ userId, email }, transaction);
+          } else {
+            await MailerService.sendVerificationCode({ code: codeGenerated, email });
+          }
+
+          return actionStatus;
+        }
+
+        // update user's phone number
+        if (phone) {
+          const { actionStatus, codeGenerated } =
+            await this.updateProfileConfirmableField(
+              {
+                field: 'phone',
+                value: phone,
+                provider: NotifiedProviderEnum.sms,
+                code,
+              },
+              transaction
+            );
+
+          if (actionStatus === 'updated') {
+            await UserService.updatePhone({ userId, phone }, transaction);
+          } else {
+            await SMSService.sendVerificationCode({ code: codeGenerated, phone });
+          }
+
+          return actionStatus;
+        }
+
+        // update user's full name.
+        if (fullname) {
+          await UserService.updateFullname({ userId, fullname }, transaction);
+          return 'updated';
+        }
+
+        return 'no-action';
+      }
+    );
+
+    return { data: { status } };
+  }
+
+  /**
    * Get user profile by their ID.
    */
   static async getProfile({ userId }: ProfileParams): ProfileResult {
@@ -409,6 +483,47 @@ class UserController extends BaseController {
         teams,
       },
     };
+  }
+
+  private static async updateProfileConfirmableField(
+    { field, value, provider, code }: UpdateProfileFieldParams,
+    transaction?: Transaction
+  ): Promise<UpdateProfileFieldResult> {
+    if (code) {
+      const verificationCode = await VerificationCodeService.getVerificationCode({
+        code,
+        [field]: value,
+      });
+
+      if (!verificationCode) {
+        throw new BadRequest({
+          errorCode: UserErrorEnum.invalidVerificationCode,
+          message: 'Your provided verification code is invalid or is expired.',
+        });
+      }
+
+      await VerificationCodeService.removeVerificationCode(
+        {
+          [field]: value,
+          code,
+        },
+        transaction
+      );
+
+      return { actionStatus: 'updated', codeGenerated: null };
+    }
+
+    const codeGenerated = await VerificationCodeService.generate();
+    await VerificationCodeService.store(
+      {
+        code: codeGenerated,
+        [field]: value,
+        provider: provider,
+      },
+      transaction
+    );
+
+    return { actionStatus: 'confirmation-sent', codeGenerated };
   }
 
   private static async mergeUserAndTeams(user: Nullable<User>): Promise<UserAndTeams> {

--- a/apis/core-api/src/core/controllers/UserController/types.ts
+++ b/apis/core-api/src/core/controllers/UserController/types.ts
@@ -124,3 +124,29 @@ export type UserAndTeams = Nullable<
     teams: Array<ResourceIdentifier>;
   }
 >;
+
+export type UpdateProfileStatusType = 'confirmation-sent' | 'updated' | 'no-action';
+export type UpdateProfileFieldType = 'phone' | 'email' | 'fullname';
+
+export type UpdateProfileFieldParams = {
+  field: UpdateProfileFieldType;
+  value: string;
+  provider: NotifiedProviderEnum;
+  code?: string;
+};
+export type UpdateProfileFieldResult = {
+  actionStatus: UpdateProfileStatusType;
+  codeGenerated: Nullable<string>;
+};
+
+export type UpdateProfileParams = {
+  userId: ResourceIdentifier;
+  code?: string;
+  phone?: string;
+  email?: string;
+  fullname?: string;
+};
+
+export type UpdateProfileResult = ControllerResultType<{
+  status: UpdateProfileStatusType;
+}>;

--- a/apis/core-api/src/core/services/UserService.ts
+++ b/apis/core-api/src/core/services/UserService.ts
@@ -12,6 +12,9 @@ interface IUserUniqueIdentifier {
   username?: null | string;
   id?: null | ResourceIdentifier;
 }
+
+type UpdateProfile<T> = T & { userId: ResourceIdentifier };
+
 class UserService extends BaseService {
   /**
    * Check username is taken.
@@ -142,6 +145,42 @@ class UserService extends BaseService {
   ): ServiceResultType<null | User> {
     // TODO: write logic to create user and send notification
     return null;
+  }
+
+  /**
+   * Update user's phone number.
+   */
+  static async updatePhone(
+    params: UpdateProfile<{ phone: string }>,
+    transaction?: Transaction
+  ) {
+    const user = await db.User.findByPk(params.userId);
+    user.setDataValue('phone', params.phone);
+    await user.save({ transaction });
+  }
+
+  /**
+   * Update user's email address.
+   */
+  static async updateEmail(
+    params: UpdateProfile<{ email: string }>,
+    transaction?: Transaction
+  ) {
+    const user = await db.User.findByPk(params.userId);
+    user.setDataValue('email', params.email);
+    await user.save({ transaction });
+  }
+
+  /**
+   * Update user's full name.
+   */
+  static async updateFullname(
+    params: UpdateProfile<{ fullname: string }>,
+    transaction?: Transaction
+  ) {
+    const user = await db.User.findByPk(params.userId);
+    user.setDataValue('fullname', params.fullname);
+    await user.save({ transaction });
   }
 }
 


### PR DESCRIPTION
Added functionality to update following fields on user's profile:

- `email` - requires confirmation
- `phone` - requires confirmation
- `fullname` - updates immediately

---

The field which required confirmation must be called twice (in the second one confirmation code must be provided, e.g. email update):


#### Step 1 - Requesting to edit.
Request to `PUT: https://api.ultras.app/api/v1/users/me`.
```json
{
  "email": "john.doe@gmail.com"
}
```

Response example:
```json
{
  "status": "confirmation-sent"
}
```

#### Step 2 - After receiving the confirmation code, the user must send the request again to the same endpoint with the confirmation code:
Request to `PUT: https://api.ultras.app/api/v1/users/me`.
```json
{
  "email": "john.doe@gmail.com",
  "code": "1153"
}
```

Response example:
```json
{
  "status": "updated"
}
```


