### PR TITLE
[fix] Query interface of sequelize renamed.

### DIFF
--- a/apis/core-api/src/core/data/seeders/20220301194201-fan-club-role-seeder.ts
+++ b/apis/core-api/src/core/data/seeders/20220301194201-fan-club-role-seeder.ts
@@ -1,4 +1,4 @@
-import { Sequelize, IQuery } from 'sequelize';
+import { Sequelize, QueryInterface } from 'sequelize';
 import { FanClubMemberRoleEnum } from '@ultras/utils';
 import { ULTRAS_CORE } from '../lcp/schemas';
 
@@ -8,8 +8,8 @@ const table = {
 };
 
 module.exports = {
-  async up(Iquery: IQuery, sequelize: Sequelize) {
-    return Iquery.bulkInsert(table, [
+  async up(queryInterface: QueryInterface, sequelize: Sequelize) {
+    return queryInterface.bulkInsert(table, [
       {
         role: FanClubMemberRoleEnum.owner,
         description: 'Fan club owner role.',
@@ -31,7 +31,7 @@ module.exports = {
     ]);
   },
 
-  async down(Iquery: IQuery, sequelize: Sequelize) {
-    return Iquery.bulkDelete('FanClubMemberRole', {}, {});
+  async down(queryInterface: QueryInterface, sequelize: Sequelize) {
+    return queryInterface.bulkDelete('FanClubMemberRole', {}, {});
   },
 };


### PR DESCRIPTION
Query interface of sequelize renamed from `IQuery` to `QueryInterface`