### PR TITLE
[fix] specify build minimum ram size for node process.

### DIFF
--- a/apis/core-api/package.json
+++ b/apis/core-api/package.json
@@ -4,7 +4,7 @@
   "description": "The core api for the ultras app",
   "main": "build/index.js",
   "scripts": {
-    "build": "rimraf ./build && tsc --rootDir src",
+    "build": "rimraf ./build && NODE_OPTIONS=--max-old-space-size=4096 tsc --rootDir src",
     "dev": "nodemon",
     "prod": "NODE_ENV=production pm2 start build/api/index.js --env production --name ultras-api",
     "test": "echo Error: no test specified && exit 1",


### PR DESCRIPTION
#### Specify build minimum ram heap size for node process.

---

For building typescript project the compiler eats around 3-4 GB of ram, in this PR we just increase the default heap size.