### PR TITLE
[fix] Added auto-close functionality for date-picker

### DIFF
--- a/clients/app/src/views/components/base/DateTimePicker/DateTimePicker.tsx
+++ b/clients/app/src/views/components/base/DateTimePicker/DateTimePicker.tsx
@@ -1,51 +1,31 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
-import DateTimePicker from '@react-native-community/datetimepicker';
-import { Box, Text } from 'native-base';
+import PickerWrapper from './PickerWrapper';
 import { IDatePickerProps } from './types';
 
-export const DatePicker: React.FC<IDatePickerProps> = ({ text, value, onChange }) => {
+export const DatePicker: React.FC<IDatePickerProps> = ({
+  autoclose = true,
+  ...restProps
+}) => {
   return (
-    <Box style={styles.relative}>
-      <Text variant={'matchDate'}>{text}</Text>
-      <Box style={styles.hidden}>
-        <DateTimePicker
-          value={value}
-          mode={'date'}
-          onChange={onChange}
-          minimumDate={new Date()}
-          display="compact"
-          themeVariant="dark"
-        />
-      </Box>
-    </Box>
+    <PickerWrapper
+      mode={'date'}
+      minimumDate={new Date()}
+      autoclose={autoclose}
+      {...restProps}
+    />
   );
 };
 
-export const TimePicker: React.FC<IDatePickerProps> = ({ text, value, onChange }) => {
+export const TimePicker: React.FC<IDatePickerProps> = ({
+  autoclose = false,
+  ...restProps
+}) => {
   return (
-    <Box style={styles.relative}>
-      <Text variant={'matchDate'}>{text}</Text>
-      <Box style={styles.hidden}>
-        <DateTimePicker
-          value={value}
-          mode={'time'}
-          onChange={onChange}
-          minuteInterval={10}
-          display="compact"
-          themeVariant="dark"
-        />
-      </Box>
-    </Box>
+    <PickerWrapper
+      mode={'time'}
+      minuteInterval={10}
+      autoclose={autoclose}
+      {...restProps}
+    />
   );
 };
-
-const styles = StyleSheet.create({
-  relative: { position: 'relative' },
-  hidden: {
-    position: 'absolute',
-    width: '100%',
-    height: '100%',
-    opacity: 0,
-  },
-});

--- a/clients/app/src/views/components/base/DateTimePicker/PickerWrapper.tsx
+++ b/clients/app/src/views/components/base/DateTimePicker/PickerWrapper.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { Box, Pressable, Text } from 'native-base';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { OnChangeInterface, PickerWrapperProps } from './types';
+
+const PickerWrapper: React.FC<PickerWrapperProps> = ({
+  autoclose = true,
+  text,
+  value,
+  onChange,
+  ...rest
+}) => {
+  const [opened, setOpened] = React.useState<boolean>(true);
+
+  const onValueChange: OnChangeInterface = React.useCallback(
+    (event, date) => {
+      if (typeof onChange === 'function') {
+        onChange(event, date);
+      }
+
+      if (autoclose) {
+        setOpened(false);
+        setTimeout(() => {
+          setOpened(true);
+        }, 10);
+      }
+    },
+    [autoclose, onChange]
+  );
+
+  const triggerOpen = React.useCallback(() => {
+    setOpened(true);
+  }, []);
+
+  return (
+    <Box style={styles.relative}>
+      <Pressable onPress={triggerOpen}>
+        <Text variant={'matchDate'}>{text}</Text>
+      </Pressable>
+
+      {opened && (
+        <Box style={styles.hidden}>
+          <DateTimePicker
+            {...rest}
+            value={value}
+            onChange={onValueChange}
+            display="compact"
+            themeVariant="dark"
+          />
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default PickerWrapper;
+
+const styles = StyleSheet.create({
+  relative: { position: 'relative' },
+  hidden: {
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+    opacity: 0,
+  },
+});

--- a/clients/app/src/views/components/base/DateTimePicker/types.ts
+++ b/clients/app/src/views/components/base/DateTimePicker/types.ts
@@ -1,7 +1,19 @@
-import { DateTimePickerEvent } from '@react-native-community/datetimepicker/src/types';
+import {
+  AndroidNativeProps,
+  IOSNativeProps,
+  DateTimePickerEvent,
+} from '@react-native-community/datetimepicker';
+
+export interface OnChangeInterface {
+  (event: DateTimePickerEvent, date?: Date | undefined): void;
+}
 
 export interface IDatePickerProps {
+  autoclose?: boolean;
   text: string;
   value: Date;
-  onChange?: (event: DateTimePickerEvent, date?: Date | undefined) => void;
+  onChange?: OnChangeInterface;
 }
+
+type NativeProps = IOSNativeProps | AndroidNativeProps;
+export type PickerWrapperProps = IDatePickerProps & NativeProps;


### PR DESCRIPTION
#### This PR includes:

---

- Added auto-close functionality for date-picker and it can be disabled by adding `autoclose={false}` prop.
- Moved duplication code logic to wrapper component.